### PR TITLE
fix: Fix NDArray::prod memory leak when using a PHP array as argument

### DIFF
--- a/numpower.c
+++ b/numpower.c
@@ -3778,6 +3778,7 @@ PHP_METHOD(NDArray, prod)
         rtn = reduce(nda, &axis_i, NDArray_Multiply_Float);
     } else {
         value = NDArray_Float_Prod(nda);
+        CHECK_INPUT_AND_FREE(a, nda);
         RETURN_DOUBLE(value);
         return;
     }


### PR DESCRIPTION
When calling `nd::prod` with a PHP function as below the temporary `NDArray* nda` is not freed automatically.

```php
$a = nd::prod([[1, 2], [3, 4]]);
```

I added the code below to check and free the input before returning when only one argument is provided to the function

```C
...
value = NDArray_Float_Prod(nda);
        CHECK_INPUT_AND_FREE(a, nda);  // Check if nda is temporary and free before return
        RETURN_DOUBLE(value);
````