### PR TITLE
fix: Fixed double definition of envvar

### DIFF
--- a/numpower.c
+++ b/numpower.c
@@ -4097,12 +4097,12 @@ PHP_MSHUTDOWN_FUNCTION(ndarray) {
 
 PHP_RSHUTDOWN_FUNCTION(ndarray) {
     char *envvar = "NDARRAY_FREEBUFFER";
+    char *envvar_vcheck = "NDARRAY_VCHECK";
     if(getenv(envvar)) {
         buffer_free();
     }
 #ifdef HAVE_CUBLAS
-    char *envvar = "NDARRAY_VCHECK";
-    if(getenv(envvar)) {
+    if(getenv(envvar_vcheck)) {
         NDArray_VCHECK();
     }
 #endif


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Fix compilation error when using CUDA

```
2.607 ./numpower.c: In function 'zm_deactivate_ndarray':
2.608 ./numpower.c:4104:11: error: redefinition of 'envvar'
2.608      char *envvar = "NDARRAY_VCHECK";
2.608            ^~~~~~
2.608 ./numpower.c:4099:11: note: previous definition of 'envvar' was here
2.608      char *envvar = "NDARRAY_FREEBUFFER";
2.608            ^~~~~~
2.627 make: *** [Makefile:276: install-cuda] Error 1
```

#### What is the current behavior? (You can also link to an open issue here)

During compilation with CUDA enabled, the compiler fails because `envvar` ends up being declared twice. 

#### What is the new behavior (if this is a feature change)?

Change `envvar` to `envvar_vcheck` for VCHECK to avoid declaring the variable twice.



