### PR TITLE
Bug fix patch

### DIFF
--- a/numpower.c
+++ b/numpower.c
@@ -317,9 +317,7 @@ PHP_METHOD(NDArray, fill) {
     if (array == NULL) {
         return;
     }
-    rtn = NDArray_Fill(array, (float)value);
-    NDArray_ADDREF(array);
-    RETURN_NDARRAY_NOBUFFER(rtn, return_value);
+    NDArray_Fill(array, (float)value);
 }
 
 ZEND_BEGIN_ARG_INFO(arginfo_toArray, 0)

--- a/numpower.c
+++ b/numpower.c
@@ -421,9 +421,9 @@ PHP_METHOD(NDArray, isGPU) {
     NDArray* array = ZVAL_TO_NDARRAY(obj_zval);
 
     if (NDArray_DEVICE(array) == NDARRAY_DEVICE_CPU) {
-        RETURN_LONG(1);
-    } else {
         RETURN_LONG(0);
+    } else {
+        RETURN_LONG(1);
     }
 }
 


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)


Fix NDArray_Fill method memory error
Fixed isGPU method to return value correctly

#### What is the current behavior? (You can also link to an open issue here)

NDArray_Fill was causing the device to release memory prematurely.

```
[z=](php: ./src/buffer.c:81: buffer_get: Assertion `MAIN_MEM_STACK.buffer[uuid] != NULL' failed.)
```

NDArray_isGPU was returning incorrect values.