### PR TITLE
NDArray_Append, slicing bug fix, AVX2 image support and AVX2 CUDA support

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -67,19 +67,19 @@ COMMON_FLAGS = $(DEFS) $(INCLUDES) $(EXTRA_INCLUDES) $(CPPFLAGS) $(PHP_FRAMEWORK
 install-cuda:
 	rm ./.libs -rf
 	mkdir ./.libs
-	$(NVCC) -I. -I  $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./numpower.c -shared -Xcompiler -fPIC -o .libs/numpower.o
+	$(NVCC)  -I. -I  $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./numpower.c -shared -Xcompiler -fPIC -o .libs/numpower.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/buffer.c -shared -Xcompiler -fPIC -o .libs/buffer.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/debug.c -shared -Xcompiler -fPIC -o .libs/debug.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/indexing.c -shared -Xcompiler -fPIC -o .libs/indexing.o
-	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/initializers.c -shared -Xcompiler -fPIC -o .libs/initializers.o
+	$(CC)    -I. -I $(CXX) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/initializers.c -shared -fPIC -o .libs/initializers.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/iterators.c -shared -Xcompiler -fPIC -o .libs/iterators.o
-	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/logic.c -shared -Xcompiler -fPIC -o .libs/logic.o
-	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/manipulation.c -shared -Xcompiler -fPIC -o .libs/manipulation.o
-	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndarray.c -shared -Xcompiler -fPIC -o .libs/ndarray.o
+	$(CC)    -I. -I $(CXX) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/logic.c -shared -fPIC -o .libs/logic.o
+	$(CC)    -I. -I $(CXX) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/manipulation.c -shared -fPIC -o .libs/manipulation.o
+	$(CC)    -I. -I $(CXX) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndarray.c -shared -fPIC -o .libs/ndarray.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/types.c -shared -Xcompiler -fPIC -o .libs/types.o
-	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/arithmetics.c -shared -Xcompiler -fPIC -o .libs/arithmetics.o
+	$(CC)    -I. -I $(CXX) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/arithmetics.c -shared -fPIC -o .libs/arithmetics.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/double_math.c -shared -Xcompiler -fPIC -o .libs/double_math.o
-	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/linalg.c -shared -Xcompiler -fPIC -o .libs/linalg.o
+	$(CC)    -I. -I $(CXX) $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/linalg.c -shared -fPIC -o .libs/linalg.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/gpu_alloc.c -shared -Xcompiler -fPIC -o .libs/gpu_alloc.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/cuda/cuda_math.cu -shared -Xcompiler -fPIC -o .libs/cuda_math.o
 	$(NVCC)  -I. -I $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS)  $(ALL_CCFLAGS) $(GENCODE_FLAGS)  -c $(builddir)./src/ndmath/statistics.c -shared -Xcompiler -fPIC -o .libs/statistics.o

--- a/config.m4
+++ b/config.m4
@@ -15,6 +15,18 @@ if test "$PHP_CUDA" != "no"; then
       AC_MSG_RESULT([CUBLAS detected ])
       PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/Makefile.frag, $abs_builddir)
       CFLAGS+=" -lcublas -lcudart "
+      AC_CHECK_HEADER([immintrin.h],
+              [
+                AC_DEFINE(HAVE_AVX2,1,[Have AV2/SSE support])
+                AC_MSG_RESULT([AVX2/SSE detected ])
+                CXX+=" -mavx2 -march=native "
+              ],[
+                AC_DEFINE(HAVE_AVX2,0,[Have AV2/SSE support])
+                AC_MSG_RESULT([AVX2/SSE not found ])
+              ], [
+
+              ]
+          )
     ],[
         AC_MSG_RESULT([wrong cublas version or library not found.])
         AC_CHECK_HEADER([immintrin.h],

--- a/numpower.c
+++ b/numpower.c
@@ -3018,6 +3018,37 @@ PHP_METHOD(NDArray, add) {
 }
 
 /**
+ * NDArray::inner
+ */
+ZEND_BEGIN_ARG_INFO(arginfo_ndarray_append, 0)
+ZEND_ARG_INFO(0, a)
+ZEND_ARG_INFO(0, b)
+ZEND_END_ARG_INFO()
+PHP_METHOD(NDArray, append) {
+    NDArray *rtn = NULL;
+    zval *a, *b;
+    long axis;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_ZVAL(a)
+        Z_PARAM_ZVAL(b)
+    ZEND_PARSE_PARAMETERS_END();
+    NDArray *nda = ZVAL_TO_NDARRAY(a);
+    NDArray *ndb = ZVAL_TO_NDARRAY(b);
+    if (nda == NULL) {
+    return;
+    }
+    if (ndb == NULL) {
+    CHECK_INPUT_AND_FREE(a, nda);
+    return;
+    }
+    rtn = NDArray_Append(nda, ndb);
+
+    CHECK_INPUT_AND_FREE(a, nda);
+    CHECK_INPUT_AND_FREE(b, ndb);
+    RETURN_NDARRAY(rtn, return_value);
+}
+
+/**
  * NDArray::matmul
  */
 ZEND_BEGIN_ARG_INFO(arginfo_ndarray_matmul, 0)
@@ -3927,6 +3958,7 @@ static const zend_function_entry class_NDArray_methods[] = {
     ZEND_ME(NDArray, atleast_3d, arginfo_ndarray_atleast_3d, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, transpose, arginfo_ndarray_transpose, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, slice, arginfo_ndarray_slice, ZEND_ACC_PUBLIC)
+    ZEND_ME(NDArray, append, arginfo_ndarray_append, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 
     // INDEXING
     ZEND_ME(NDArray, diagonal, arginfo_ndarray_diagonal, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/src/initializers.c
+++ b/src/initializers.c
@@ -295,7 +295,7 @@ NDArray*
 NDArray_FromNDArray(NDArray *target, int buffer_offset, int* shape, int* strides, const int* ndim) {
     NDArray* rtn = emalloc(sizeof(NDArray));
     int total_num_elements = 1;
-    int out_ndim;
+    int out_ndim = -1;
 
     if (strides == NULL) {
         rtn->strides = emalloc(sizeof(int) * NDArray_NDIM(target));
@@ -310,7 +310,9 @@ NDArray_FromNDArray(NDArray *target, int buffer_offset, int* shape, int* strides
     if (shape != NULL) {
         rtn->dimensions = shape;
         rtn->strides = strides;
-        out_ndim = *ndim;
+        if (out_ndim == -1) {
+            out_ndim = *ndim;
+        }
     }
 
     // Calculate number of elements

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -237,6 +237,7 @@ NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices, int return_vie
         }
         slice_shape[0] = (int)floorf(((float)stop - (float)start) / (float)step);
         slice_strides[0] = NDArray_STRIDES(array)[0];
+        offset = start * NDArray_STRIDES(array)[0];
         slice = NDArray_FromNDArray(array, offset, slice_shape, slice_strides, &out_ndim);
         return slice;
     }

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -218,6 +218,29 @@ NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices, int return_vie
         return NULL;
     }
 
+    if (NDArray_NDIM(array) == 1) {
+        int out_ndim = NDArray_NDIM(array);
+        if (NDArray_NUMELEMENTS(indexes[0]) >= 1) {
+            start = (int) NDArray_FDATA(indexes[0])[0];
+        } else {
+            start = 0;
+        }
+        if (NDArray_NUMELEMENTS(indexes[0]) >= 2) {
+            stop  = (int)NDArray_FDATA(indexes[0])[1];
+        } else {
+            stop = NDArray_SHAPE(array)[0];
+        }
+        if (NDArray_NUMELEMENTS(indexes[0]) == 3) {
+            step  = (int)NDArray_FDATA(indexes[0])[2];
+        } else {
+            step = 1;
+        }
+        slice_shape[0] = (int)floorf(((float)stop - (float)start) / (float)step);
+        slice_strides[0] = NDArray_STRIDES(array)[0];
+        slice = NDArray_FromNDArray(array, offset, slice_shape, slice_strides, &out_ndim);
+        return slice;
+    }
+
     for (i = 0; i < num_indices; i++) {
         if (NDArray_NUMELEMENTS(indexes[i]) >= 1) {
             start = (int) NDArray_FDATA(indexes[i])[0];
@@ -263,7 +286,45 @@ NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices, int return_vie
     slice->strides = Generate_Strides(slice_shape, slice_ndim, NDArray_ELSIZE(slice));
     slice->base = NULL;
     NDArray_FREE(array);
-    NDArray_Print(slice,0);
     efree(slice_strides);
     return slice;
+}
+
+/**
+ * @param target
+ * @todo Append all dimensions with axis
+ * @return
+ */
+NDArray*
+NDArray_Append(NDArray *a, NDArray *b) {
+    char *tmp_ptr;
+    if (NDArray_DEVICE(a) != NDArray_DEVICE(b)) {
+        zend_throw_error(NULL, "NDArrays must be on the same device.");
+        return NULL;
+    }
+
+    if (NDArray_NDIM(a) != 1 || NDArray_NDIM(b) != 1) {
+        zend_throw_error(NULL, "You can only append vectors.");
+        return NULL;
+    }
+
+    int *shape = emalloc(sizeof(int));
+    shape[0] = NDArray_NUMELEMENTS(a) + NDArray_NUMELEMENTS(b);
+    NDArray* rtn = NDArray_Empty(shape, 1, NDArray_TYPE(a), NDArray_DEVICE(a));
+
+    if (NDArray_DEVICE(a) == NDARRAY_DEVICE_GPU) {
+#ifdef HAVE_CUBLAS
+        NDArray_VMEMCPY_D2D(NDArray_DATA(a), NDArray_DATA(rtn), NDArray_ELSIZE(a) * NDArray_NUMELEMENTS(a));
+        tmp_ptr = NDArray_DATA(rtn) + NDArray_ELSIZE(a) * NDArray_NUMELEMENTS(a);
+        NDArray_VMEMCPY_D2D(NDArray_DATA(b), tmp_ptr, NDArray_ELSIZE(b) * NDArray_NUMELEMENTS(b));
+#endif
+    }
+
+    if (NDArray_DEVICE(a) == NDARRAY_DEVICE_CPU) {
+        memcpy(NDArray_DATA(rtn), NDArray_DATA(a), NDArray_ELSIZE(a) * NDArray_NUMELEMENTS(a));
+        tmp_ptr = NDArray_DATA(rtn) + NDArray_ELSIZE(a) * NDArray_NUMELEMENTS(a);
+        memcpy(tmp_ptr, NDArray_DATA(b), NDArray_ELSIZE(b) * NDArray_NUMELEMENTS(b));
+    }
+
+    return rtn;
 }

--- a/src/manipulation.h
+++ b/src/manipulation.h
@@ -10,5 +10,6 @@ void reverse_copy(const int* src, int* dest, int size);
 void copy(const int* src, int* dest, unsigned int size);
 NDArray* NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices, int return_view);
 void *linearize_FLOAT_matrix(float *dst_in, float *src_in, NDArray * a);
+NDArray* NDArray_Append(NDArray *a, NDArray *b);
 
 #endif //PHPSCI_NDARRAY_MANIPULATION_H

--- a/src/ndmath/linalg.c
+++ b/src/ndmath/linalg.c
@@ -1080,7 +1080,7 @@ convolve2d_same_float(const float* a, const float* b, const int* shape_a,
 NDArray*
 NDArray_Convolve2D(NDArray *a, NDArray *b, char mode, char boundary, float fill_value) {
     if (NDArray_DEVICE(a) != NDArray_DEVICE(b)) {
-        zend_throw_error(NULL, "Device error.");
+        zend_throw_error(NULL, "Both arrays must be at the same device.");
         return NULL;
     }
 


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

[feat: NDArray_Append for vectors](https://github.com/NumPower/numpower/commit/e9d8bcf1e3d053aa151c7ac030b5374d7cbaeac2)
Implement NDArray::append static function to append two vectors. (Only vectors are supported for now)

[fix: Fixed NDArray_Slice when slicing vectors](https://github.com/NumPower/numpower/commit/812d4bc557c20fc8e37e2abc9ea16a5fa3ae4ad8)
Fixed a segmentation fault when slicing vectors

[feat: Use AVX2 for image loading and saving](https://github.com/NumPower/numpower/commit/2152d7b39cf7e64c8bc97a701d225da2ec206957)
Make use o AVX2 when available to load and save GDImage objects.

[feat: Enable AVX2 when using CUDA](https://github.com/NumPower/numpower/commit/86efdd21621731331f16064cf07be6f540a72272)
Allow functions that support AVX2 to use it when available even when NDArray is compiled with CUDA support.
