### PR TITLE
GD Image loading and save fix, GPU allocation improvement and GPU slicing fixes

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,73 +1,113 @@
-// Comments in this file start with '//'.
-// Remove where necessary.
+ARG_ENABLE("ndarray",
+  "whether to enable ndarray support",
+  "Enable ndarray support",
+  "no")
 
-ARG_ENABLE('ndarray', 'whether to enable ndarray support', 'no')
+ARG_WITH("cuda", "for CUDA support",
+  "Include CUDA support", "no", "no")
 
-if PHP_NDARRAY != "no"; then
-  // Check for CUBLAS library
-  PHP_CHECK_LIBRARY('cublas', 'cublasDgemm', '
-    ARG_ENABLE("cublas", "Enable CUBLAS support", "no")
-    AC_MSG_RESULT(["CUBLAS detected"])
-    CFLAGS = CFLAGS + " -lcublas -lcudart "
-  ', '
-    AC_MSG_RESULT(["Wrong CUBLAS version or library not found."])
-  ')
+if test x%PHP_CUDA% != xno; then
+    CHECK_LIB("cublas", "cublasDgemm", ,
+      [
+        AC_DEFINE("HAVE_CUBLAS", 1)
+        PHP_ADD_LIBRARY("cublas", , "NDARRAY_SHARED_LIBADD")
+        AC_MSG_RESULT("CUBLAS detected")
+        PHP_ADD_MAKEFILE_FRAGMENT("$abs_srcdir/Makefile.frag", "$abs_builddir")
+        CFLAGS+=" -lcublas -lcudart"
+        AC_CHECK_HEADER("immintrin.h",
+          [
+            AC_DEFINE("HAVE_AVX2", 1)
+            AC_MSG_RESULT("AVX2/SSE detected")
+            CXX+=" -mavx2 -march=native"
+          ],
+          [
+            AC_DEFINE("HAVE_AVX2", 0)
+            AC_MSG_RESULT("AVX2/SSE not found")
+          ],
+          []
+        )
+      ],
+      [
+        AC_MSG_RESULT("wrong cublas version or library not found.")
+        AC_CHECK_HEADER("immintrin.h",
+          [
+            AC_DEFINE("HAVE_AVX2", 1)
+            AC_MSG_RESULT("AVX2/SSE detected")
+            CFLAGS+=" -mavx2 -march=native"
+          ],
+          [
+            AC_DEFINE("HAVE_AVX2", 0)
+            AC_MSG_RESULT("AVX2/SSE not found")
+          ],
+          []
+        )
+      ]
+    )
+else
+    AC_CHECK_HEADER("immintrin.h",
+      [
+        AC_DEFINE("HAVE_AVX2", 1)
+        AC_MSG_RESULT("AVX2/SSE detected")
+        CFLAGS+=" -mavx2 -march=native"
+      ],
+      [
+        AC_DEFINE("HAVE_AVX2", 0)
+        AC_MSG_RESULT("AVX2/SSE not found")
+      ],
+      []
+    )
+fi
 
-  // Check for AVX2 support
-  PHP_CHECK_HEADER('immintrin.h', '
-    AC_DEFINE("HAVE_AVX2", 1, ["Have AVX2/SSE support"])
-    AC_MSG_RESULT(["AVX2/SSE detected"])
-    CFLAGS = CFLAGS + " -mavx2 "
-  ', '
-    AC_DEFINE("HAVE_AVX2", 0, ["Have AVX2/SSE support"])
-    AC_MSG_RESULT(["AVX2/SSE not found"])
-  ')
+if test x%PHP_GD% != xno; then
+    AC_DEFINE("HAVE_GD", 1)
+    AC_MSG_RESULT("GD detected")
+    PHP_ADD_EXTENSION_DEP("ndarray", "gd", true)
+endif
 
-  // Check for CBLAS library
-  PHP_CHECK_LIBRARY('cblas', 'cblas_sdot', '
-    ARG_ENABLE("cblas", "Enable CBLAS support", "no")
-    AC_MSG_RESULT(["CBLAS detected"])
-    CFLAGS = CFLAGS + " -lcblas "
-  ', '
-    PHP_CHECK_LIBRARY('openblas', 'cblas_sdot', '
-      ARG_ENABLE("openblas", "Enable OpenBLAS support", "no")
-      AC_MSG_RESULT(["OpenBLAS detected"])
-      AC_DEFINE("HAVE_CBLAS", 1, [""])
-      CFLAGS = CFLAGS + " -lopenblas -lpthread "
-    ', '
-      AC_MSG_ERROR(["Wrong OpenBLAS/BLAS version or library not found."])
-    ', '
-      -lopenblas
-    ')
-  ', '
-    -lcblas
-  ')
+CHECK_LIB("cblas", "cblas_sdot",
+  [
+    AC_DEFINE("HAVE_CBLAS", 1)
+    PHP_ADD_LIBRARY("cblas", , "NDARRAY_SHARED_LIBADD")
+    AC_MSG_RESULT("CBlas detected")
+    CFLAGS+=" -lcblas"
+  ],
+  [
+    CHECK_LIB("openblas", "cblas_sdot",
+      [
+        PHP_ADD_LIBRARY("openblas", , "NDARRAY_SHARED_LIBADD")
+        AC_MSG_RESULT("OpenBLAS detected")
+        AC_DEFINE("HAVE_CBLAS", 1)
+        CFLAGS+=" -lopenblas -lpthread"
+      ],
+      [
+        AC_MSG_ERROR("wrong openblas/blas version or library not found.")
+      ],
+      [
+        "-lopenblas"
+      ]
+    )
+  ],
+  [
+    "-lcblas"
+  ]
+)
 
-  // Check for LAPACKE library
-  PHP_CHECK_LIBRARY('lapack', 'dgesvd_', '
-    ARG_ENABLE("lapacke", "Enable LAPACKE support", "no")
-    AC_MSG_RESULT(["LAPACKE detected"])
-    CFLAGS = CFLAGS + " -llapack -llapacke "
-  ', '
-    AC_MSG_ERROR(["Wrong LAPACKE version or library not found."])
-  ')
+CHECK_LIB("lapacke", "LAPACKE_sgesdd",
+  [
+    AC_DEFINE("HAVE_LAPACKE", 1)
+    PHP_ADD_LIBRARY("lapack", , "NDARRAY_SHARED_LIBADD")
+    AC_MSG_RESULT("LAPACKE detected")
+    CFLAGS+=" -llapack -llapacke"
+  ],
+  [
+    AC_MSG_ERROR("wrong LAPACKE version or library not found. Try `apt install liblapacke-dev`")
+  ]
+)
 
-  // Add your extension's source files
-  PHP_ADD_EXTENSION('ndarray', '
-    numpower.c \
-    src/initializers.c \
-    src/ndmath/double_math.c \
-    src/ndarray.c \
-    src/debug.c \
-    src/buffer.c \
-    src/logic.c \
-    src/gpu_alloc.c \
-    src/ndmath/linalg.c \
-    src/manipulation.c \
-    src/iterators.c \
-    src/indexing.c \
-    src/ndmath/arithmetics.c \
-    src/ndmath/statistics.c \
-    src/types.c
-  ')
+if test x%PHP_NDARRAY% != xno; then
+  AC_DEFINE("HAVE_NDARRAY", 1, "Have ndarray support")
+  PHP_NEW_EXTENSION("ndarray",
+      "numpower.c src/initializers.c src/ndmath/double_math.c src/ndarray.c src/debug.c src/buffer.c src/logic.c src/gpu_alloc.c src/ndmath/linalg.c src/manipulation.c src/iterators.c src/indexing.c src/ndmath/arithmetics.c src/ndmath/statistics.c src/types.c",
+      %ext_shared%
+  )
 endif

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -62,7 +62,6 @@ void buffer_free() {
  */
 void buffer_ndarray_free(int uuid) {
     if (MAIN_MEM_STACK.buffer != NULL) {
-        // @todo investigate double free problem
         if (MAIN_MEM_STACK.lastFreed == -1) {
             MAIN_MEM_STACK.lastFreed = uuid;
         }

--- a/src/gpu_alloc.c
+++ b/src/gpu_alloc.c
@@ -1,4 +1,5 @@
 #include "../config.h"
+#include <Zend/zend.h>
 
 #ifdef HAVE_CUBLAS
 #include "gpu_alloc.h"
@@ -9,27 +10,26 @@
 void
 NDArray_VMALLOC(void** target, unsigned int size) {
     MAIN_MEM_STACK.totalGPUAllocated++;
-    cudaMalloc(target, size);
-    cudaDeviceSynchronize();
+    cublasStatus_t stat = cudaMalloc(target, size);
+    if (stat != cudaSuccess) {
+        zend_throw_error(NULL, "device memory allocation failed");
+    }
 }
 
 void
 NDArray_VMEMCPY_D2D(char* target, char* dst, unsigned int size) {
     cudaMemcpy(dst, target, size, cudaMemcpyDeviceToDevice);
-    cudaDeviceSynchronize();
 }
 
 void
 NDArray_VMEMCPY_H2D(char* target, char* dst, unsigned int size) {
     cudaMemcpy(dst, target, size, cudaMemcpyHostToDevice);
-    cudaDeviceSynchronize();
 }
 
 void
 NDArray_VFREE(void* target) {
     MAIN_MEM_STACK.totalGPUAllocated--;
     cudaFree(target);
-    cudaDeviceSynchronize();
 }
 
 void

--- a/src/logic.c
+++ b/src/logic.c
@@ -18,7 +18,6 @@
 /**
  * Check if all values are not 0
  *
- * @todo Implement non-AVX2 logic
  * @param a
  * @return
  */

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -206,17 +206,17 @@ linearize_FLOAT_matrix(float *dst_in,
 
 NDArray*
 NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices, int return_view) {
+    if (num_indices > NDArray_NDIM(array)) {
+        zend_throw_error(NULL, "too many indices for array");
+        return NULL;
+    }
+
     NDArray *slice, *rtn;
     int slice_ndim = NDArray_NDIM(array);
     int *slice_shape = emalloc(sizeof(int) * slice_ndim);
     int *slice_strides = emalloc(sizeof(int) * slice_ndim);
     int i, offset = 0;
     int start = 0, stop = 0, step = 0;
-
-    if (num_indices > NDArray_NDIM(array)) {
-        zend_throw_error(NULL, "too many indices for array");
-        return NULL;
-    }
     if (NDArray_NDIM(array) == 1) {
         int out_ndim = NDArray_NDIM(array);
         if (NDArray_NUMELEMENTS(indexes[0]) >= 1) {


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

[fix: Missing pixel values when opening a GD image](https://github.com/NumPower/numpower/commit/9417c8561bd981a82598dd8c00901a3c84f799e3)
[fix: Missing pixel values when saving a GD image](https://github.com/NumPower/numpower/commit/274535e6d6b671d59a71ce747ae491d77f76d89f)

When using AVX2 hardware, converted GD images to NDArray were missing some pixels values because both NDArray_ToGD and NDArray_FromGD were not handling the remainings of the AVX operation.

[fix: Remove unnecessary CUDA device sync from gpu_alloc](https://github.com/NumPower/numpower/commit/30baca52437503caccb909deacf56cbdd4e74f6e)

There is no need to resynchronize the CUDA device for every operation, this was also causing the cuBLAS calls to hang.

[fix: Fix column strides when slicing NDArrays stored on GPU](https://github.com/NumPower/numpower/commit/ced98bba4b9a86e20ae3e322a1ac3a33a8d5f75b)

Slicing with GPU was broken, this fix the behaviour.

[fix: Prevent memory leak when NDArray_Slice fails with too many indices](https://github.com/NumPower/numpower/commit/cc84949412f3c38c614c9ce578ff1b4c3f8fc984)

When NDArray_Slice failed, the preallocated variables were not freed properly.