### PR TITLE
N-dimensional slicing and element-wise iterator

### DIFF
--- a/src/indexing.c
+++ b/src/indexing.c
@@ -44,3 +44,62 @@ NDArray_Diagonal(NDArray *target, int offset) {
 #endif
     return rtn;
 }
+
+/**
+ * @param r
+ * @param length
+ * @param start
+ * @param stop
+ * @param step
+ * @param slicelength
+ * @return
+ */
+int
+Slice_GetIndices(SliceObject *r, int length, int *start, int *stop, int *step, int *slicelength)
+{
+    int defstop;
+
+    if (r->step == NULL) {
+        *step = 1;
+    } else {
+        *step = r->step[0];
+        if (*step == 0) {
+            zend_throw_error(NULL,
+                            "slice step cannot be zero");
+            return -1;
+        }
+    }
+
+    defstop = *step < 0 ? -1 : length;
+
+    if (r->start == NULL) {
+        *start = *step < 0 ? length-1 : 0;
+    } else {
+        *start = *(r->start);
+        if (*start < 0) *start += length;
+        if (*start < 0) *start = (*step < 0) ? -1 : 0;
+        if (*start >= length) {
+            *start = (*step < 0) ? length - 1 : length;
+        }
+    }
+
+    if (r->stop == NULL) {
+        *stop = defstop;
+    } else {
+        *stop = r->stop[0];
+        if (*stop < 0) *stop += length;
+        if (*stop < 0) *stop = -1;
+        if (*stop > length) *stop = length;
+    }
+
+    if ((*step < 0 && *stop >= *start) || \
+            (*step > 0 && *start >= *stop)) {
+        *slicelength = 0;
+    } else if (*step < 0) {
+        *slicelength = (*stop - *start + 1) / (*step) + 1;
+    } else {
+        *slicelength = (*stop - *start - 1) / (*step) + 1;
+    }
+
+    return 0;
+}

--- a/src/indexing.h
+++ b/src/indexing.h
@@ -3,5 +3,12 @@
 
 #include "ndarray.h"
 
+typedef struct {
+    int *start;
+    int *stop;
+    int *step;
+} SliceObject;
+
 NDArray* NDArray_Diagonal(NDArray *target, int offset);
+int Slice_GetIndices(SliceObject *r, int length, int *start, int *stop, int *step, int *slicelength);
 #endif //PHPSCI_NDARRAY_INDEXING_H

--- a/src/initializers.c
+++ b/src/initializers.c
@@ -249,7 +249,6 @@ NDArray* Create_NDArray_FromZval(zval* php_object) {
  */
 NDArray*
 Create_NDArray(int* shape, int ndim, const char* type, const int device) {
-    char* new_buffer;
     NDArray* rtn;
     NDArrayDescriptor* descriptor;
     int type_size = get_type_size(type);

--- a/src/initializers.c
+++ b/src/initializers.c
@@ -281,6 +281,42 @@ Create_NDArray(int* shape, int ndim, const char* type, const int device) {
 }
 
 /**
+ * Create an NDArray View from another NDArray with
+ * a custom data pointer
+ *
+ * @param target
+ * @param buffer_offset
+ * @param shape
+ * @param strides
+ * @param ndim
+ * @return
+ */
+NDArray*
+NDArray_FromNDArrayBase(NDArray *target, char *data_ptr, int* shape, int* strides, const int ndim) {
+    NDArray* rtn = emalloc(sizeof(NDArray));
+    int total_num_elements = 1;
+
+    rtn->strides = strides;
+    rtn->dimensions = shape;
+
+    // Calculate number of elements
+    for (int i = 0; i < ndim; i++) {
+        total_num_elements = total_num_elements * NDArray_SHAPE(rtn)[i];
+    }
+
+    rtn->flags = 0;
+    rtn->data = data_ptr;
+    rtn->base = target;
+    rtn->ndim = ndim;
+    rtn->refcount = 1;
+    rtn->device = NDArray_DEVICE(target);
+    rtn->descriptor = Create_Descriptor(total_num_elements, sizeof(float), NDARRAY_TYPE_FLOAT32);
+    NDArrayIterator_INIT(rtn);
+    NDArray_ADDREF(target);
+    return rtn;
+}
+
+/**
  * Create an NDArray View from another NDArray
  *
  * @param target

--- a/src/initializers.h
+++ b/src/initializers.h
@@ -26,6 +26,7 @@ NDArray* NDArray_Arange(double start, double stop, double step);
 NDArray* NDArray_Binomial(int *shape, int ndim, int n, float p);
 NDArray* NDArray_EmptyLike(NDArray *a);
 NDArray* NDArray_Create(char *data, int ndim, int *shape, int device, const char* type);
+NDArray* NDArray_FromNDArrayBase(NDArray *target, char *data_ptr, int* shape, int* strides, const int ndim);
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/iterators.h
+++ b/src/iterators.h
@@ -3,11 +3,21 @@
 
 #include "ndarray.h"
 
-typedef struct NDArrayAxisIterator {
-    int current_index;
-    NDArray* array;
-    int axis;
-} NDArrayAxisIterator;
+typedef struct NDArrayIter {
+    int          nd_m1;            /* number of dimensions - 1 */
+    int          index, size;
+    int          coordinates[NDARRAY_MAX_DIMS];/* N-dimensional loop */
+    int          dims_m1[NDARRAY_MAX_DIMS];    /* ao->dimensions - 1 */
+    int          strides[NDARRAY_MAX_DIMS];    /* ao->strides or fake */
+    int          backstrides[NDARRAY_MAX_DIMS];/* how far to jump back */
+    int          factors[NDARRAY_MAX_DIMS];     /* shape factors */
+    NDArray      *ao;
+    char         *dataptr;        /* pointer to current item*/
+    bool         contiguous;
+    int          bounds[NDARRAY_MAX_DIMS][2];
+    int          limits[NDARRAY_MAX_DIMS][2];
+    int          limits_sizes[NDARRAY_MAX_DIMS];
+} NDArrayIter;
 
 NDArray* NDArrayIterator_GET(NDArray* array);
 void NDArrayIterator_INIT(NDArray* array);
@@ -21,10 +31,60 @@ void NDArrayIteratorPHP_REWIND(NDArray* array);
 int NDArrayIteratorPHP_ISDONE(NDArray* array);
 void NDArrayIteratorPHP_NEXT(NDArray* array);
 
-NDArray* NDArrayAxisIterator_GET(NDArrayAxisIterator *it);
-void NDArrayAxisIterator_NEXT(NDArrayAxisIterator *it);
-void NDArrayAxisIterator_FREE(NDArrayAxisIterator *it);
-void NDArrayAxisIterator_REWIND(NDArrayAxisIterator *it);
-int NDArrayAxisIterator_ISDONE(NDArrayAxisIterator *it);
-NDArrayAxisIterator* NDArrayAxisIterator_INIT(NDArray *array, int axis);
+NDArrayIter* NDArray_NewElementWiseIter(NDArray *target);
+
+#define _NDArray_ITER_NEXT1(it) do { \
+        (it)->dataptr += (it)->strides[0]; \
+        (it)->coordinates[0]++; \
+} while (0)
+
+#define _NDArray_ITER_NEXT2(it) do { \
+        if ((it)->coordinates[1] < (it)->dims_m1[1]) { \
+                (it)->coordinates[1]++; \
+                (it)->dataptr += (it)->strides[1]; \
+        } \
+        else { \
+                (it)->coordinates[1] = 0; \
+                (it)->coordinates[0]++; \
+                (it)->dataptr += (it)->strides[0] - \
+                        (it)->backstrides[1]; \
+        } \
+} while (0)
+
+#define NDArray_ITER_RESET(it) do { \
+        (it)->index = 0; \
+        (it)->dataptr = NDArray_DATA((it)->ao); \
+        memset((it)->coordinates, 0, \
+               ((it)->nd_m1+1)*sizeof(int)); \
+} while (0)
+
+#define NDArray_ITER_NEXT(it) do { \
+        (it)->index++; \
+        if ((it)->nd_m1 == 0) { \
+                _NDArray_ITER_NEXT1((it)); \
+        } \
+        else if ((it)->contiguous) \
+                (it)->dataptr += NDArray_DESCRIPTOR((it)->ao)->elsize; \
+        else if ((it)->nd_m1 == 1) { \
+                _NDArray_ITER_NEXT2(it); \
+        } \
+        else { \
+                int __nd_i; \
+                for (__nd_i=(it)->nd_m1; __nd_i >= 0; __nd_i--) { \
+                        if ((it)->coordinates[__nd_i] < \
+                            (it)->dims_m1[__nd_i]) { \
+                                (it)->coordinates[__nd_i]++; \
+                                (it)->dataptr += \
+                                        (it)->strides[__nd_i]; \
+                                break; \
+                        } \
+                        else { \
+                                (it)->coordinates[__nd_i] = 0; \
+                                (it)->dataptr -= \
+                                        (it)->backstrides[__nd_i]; \
+                        } \
+                } \
+        } \
+} while (0)
+#define NDArray_ITER_DATA(it) ((void *)((it)->dataptr))
 #endif //PHPSCI_NDARRAY_ITERATORS_H

--- a/src/manipulation.h
+++ b/src/manipulation.h
@@ -12,5 +12,5 @@ NDArray* NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices, int r
 void *linearize_FLOAT_matrix(float *dst_in, float *src_in, NDArray * a);
 NDArray* NDArray_Append(NDArray *a, NDArray *b);
 NDArray* NDArray_ExpandDim(NDArray *a, int axis);
-
+NDArray* NDArray_ToContiguous(NDArray *a);
 #endif //PHPSCI_NDARRAY_MANIPULATION_H

--- a/src/ndarray.c
+++ b/src/ndarray.c
@@ -320,7 +320,7 @@ void apply_single_reduce(NDArray *result, NDArray *target, float (*operation)(ND
     float tmp_result;
     int *tmp_shape = emalloc(sizeof(int));
     tmp_shape[0] = 2;
-    NDArray_Print(target, 0);
+
     NDArray *tmp = NDArray_Zeros(tmp_shape, 2, NDARRAY_TYPE_FLOAT32, NDArray_DEVICE(result));
     if (NDArray_NDIM(target) >= 1) {
         temp = operation(target);
@@ -636,6 +636,7 @@ NDArray_FREEDATA(NDArray *target) {
  */
 char *
 NDArray_Print(NDArray *array, int do_return) {
+    assert(array != NULL);
     char *str;
     if (is_type(NDArray_TYPE(array), NDARRAY_TYPE_DOUBLE64)) {
         str = print_matrix(NDArray_DDATA(array), NDArray_NDIM(array), NDArray_SHAPE(array),
@@ -1351,4 +1352,22 @@ NDArray_Overwrite(NDArray *target, NDArray *values) {
     }
 #endif
     return 0;
+}
+
+/**
+ * @param l1
+ * @param l2
+ * @param n
+ * @return
+ */
+int
+NDArray_CompareList(int const *l1, int const *l2, int n) {
+    int i;
+
+    for (i = 0; i < n; i++) {
+        if (l1[i] != l2[i]) {
+            return 0;
+        }
+    }
+    return 1;
 }

--- a/src/ndarray.h
+++ b/src/ndarray.h
@@ -9,11 +9,13 @@ extern "C" {
 #include <Zend/zend_types.h>
 #include <stdbool.h>
 
+#define NDARRAY_MAX_DIMS 128
 #define NDARRAY_ARRAY_C_CONTIGUOUS    0x0001
 #define NDARRAY_ARRAY_F_CONTIGUOUS    0x0002
 
 #define NDARRAY_UNLIKELY(x) (x)
 #define NDArray_DATA(a) ((void *)((a)->data))
+#define NDArray_DESCRIPTOR(a) ((NDArrayDescriptor *)((a)->descriptor))
 #define NDArray_DDATA(a) ((double *)((a)->data))
 #define NDArray_FDATA(a) ((float *)((a)->data))
 #define NDArray_NDIM(a) ((int)((a)->ndim))
@@ -103,6 +105,12 @@ NDArray_ENABLEFLAGS(NDArray * arr, int flags) {
     (arr)->flags |= flags;
 }
 
+static inline int
+NDArray_CHKFLAGS(const NDArray *arr, int flags)
+{
+    return ((arr)->flags & flags) == flags;
+}
+
 /*
  * Clears the specified array flags. Does no checking,
  * assumes you know what you're doing.
@@ -134,6 +142,7 @@ void NDArray_FREEDATA(NDArray *target);
 int NDArray_Overwrite(NDArray *target, NDArray *values);
 NDArray* NDArray_FromGD(zval *a, bool channel_last);
 void NDArray_ToGD(NDArray *a, NDArray *n_alpha, zval *output);
+int NDArray_CompareList(int const *l1, int const *l2, int n);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

[fix: stable N-dimensional slicing](https://github.com/NumPower/numpower/commit/11e2ebb8d0c6139a1d01918fdde9083b7542a632)
The slicing mechanism was broken for some N-dimensional matrices, this update uses a ported variation of the NumPy source code to correctly select slice indices and strides. This update also makes all returns from the slicing views instead os copies, avoiding copies in RAM memory and increasing performance.

[feat: New element-wise strided iterator.](https://github.com/NumPower/numpower/commit/6eee0831fa5cd5062d79fa5d22c78a998abb8ec3)
An element-wise iterator was implemented in the C backend to centralize and facilitate element-wise operations that must consider strides to return a correct result. This iterator is a derivative work of the iterator used by NumPy.