### PR TITLE
fix: Uses cuBLAS instead of the CUDA kernel to perform matmul

### DIFF
--- a/numpower.c
+++ b/numpower.c
@@ -237,7 +237,7 @@ static void ndarray_destructor(zend_object* object) {
     NDArrayObject* my_object = (NDArrayObject*)object;
     if (GC_REFCOUNT(object) <= 1) {
         zval *obj_uuid = OBJ_PROP_NUM(object, 0);
-        buffer_ndarray_free(Z_LVAL_P(obj_uuid));
+        buffer_ndarray_free((int)Z_LVAL_P(obj_uuid));
         zend_object_std_dtor(object);
     }
 }
@@ -754,8 +754,8 @@ PHP_METHOD(NDArray, greater_equal) {
     NDArray *nda, *ndb, *rtn = NULL;
     zval *a, *b;
     ZEND_PARSE_PARAMETERS_START(2, 2)
-    Z_PARAM_ZVAL(a)
-    Z_PARAM_ZVAL(b)
+        Z_PARAM_ZVAL(a)
+        Z_PARAM_ZVAL(b)
     ZEND_PARSE_PARAMETERS_END();
     nda = ZVAL_TO_NDARRAY(a);
     ndb = ZVAL_TO_NDARRAY(b);
@@ -3528,7 +3528,9 @@ PHP_METHOD(NDArray, matmul) {
         return;
     }
     rtn = NDArray_Matmul(nda, ndb);
-
+    if (rtn == NULL) {
+        return;
+    }
     CHECK_INPUT_AND_FREE(a, nda);
     CHECK_INPUT_AND_FREE(b, ndb);
     RETURN_NDARRAY(rtn, return_value);

--- a/src/ndmath/cuda/cuda_math.cu
+++ b/src/ndmath/cuda/cuda_math.cu
@@ -807,23 +807,6 @@ void array_sum_float(float *a, float *result, int n) {
     if (tid == 0) atomicAdd(result, sdata[0]);
 }
 
-
-
-// CUDA Kernel for Matrix Multiplication for non-square matrices
-__global__ void
-matmul_float_kernel(float* A, float* B, float* C, int widthA, int heightA, int widthB) {
-    int row = blockIdx.y * blockDim.y + threadIdx.y;
-    int col = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (row < heightA && col < widthB) {
-        float sum = 0;
-        for(int i = 0; i < widthA; ++i) {
-            sum += A[row * widthA + i] * B[i * widthB + col];
-        }
-        C[row * widthB + col] = sum;
-    }
-}
-
 __global__
 void fill_float_kernel(float* array, int n, float value) {
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
@@ -913,15 +896,6 @@ extern "C" {
         int gridSize = (n + blockSize - 1) / blockSize;
 
         fill_float_kernel<<<gridSize, blockSize>>>(a, n, value);
-        cudaDeviceSynchronize();
-    }
-
-    void
-    cuda_matmul_float(int nblocks, float *a, float *b, float *rtn, int widthA, int heightA, int widthB) {
-        dim3 blockSize(32, 32);
-        dim3 gridSize((widthB + blockSize.x - 1) / blockSize.x, (heightA + blockSize.y - 1) / blockSize.y);
-
-        matmul_float_kernel<<<gridSize, blockSize>>>(a, b, rtn, widthA, heightA, widthB);
         cudaDeviceSynchronize();
     }
 


### PR DESCRIPTION
- Creates `NDArray::save($a, string $filename)` and `NDArray::load(string $filename)`  methods for persisting NDArrays as an alternative to serialize. This may be faster in some cases.
- Remove the matmul custom kernel and use cuBLAS. There does not appear to be a significant overhead that would justify the use of a specific kernel.