### PR TITLE
GPU matmul refactoring and optimization

### DIFF
--- a/src/gpu_alloc.c
+++ b/src/gpu_alloc.c
@@ -35,7 +35,7 @@ vfree(void* target) {
 void
 vmemcheck() {
     if (MAIN_MEM_STACK.totalGPUAllocated != 0) {
-        printf("\nVRAM MEMORY LEAK: Unallocated %d arrays\n", MAIN_MEM_STACK.totalGPUAllocated);
+        printf("\nVRAM MEMORY LEAK: leaked %d array(s)\n", MAIN_MEM_STACK.totalGPUAllocated);
     }
 }
 

--- a/src/ndmath/linalg.c
+++ b/src/ndmath/linalg.c
@@ -51,23 +51,13 @@ NDArray_FMatmul(NDArray *a, NDArray *b) {
 
     if (NDArray_DEVICE(a) == NDARRAY_DEVICE_GPU) {
         // Perform GPU matrix multiplication
-#ifdef HAVE_CUBLAS
         cublasHandle_t handle;
         cublasCreate(&handle);
 
-        float* d_A;
-        float* d_B;
-        float* d_C;
-        size_t size_A = NDArray_NUMELEMENTS(a) * sizeof(float);
-        size_t size_B = NDArray_NUMELEMENTS(b) * sizeof(float);
-        size_t size_C = NDArray_NUMELEMENTS(result) * sizeof(float);
+        float* deviceResult;
+        size_t sizeResult = NDArray_NUMELEMENTS(result) * sizeof(float);
 
-        cudaMalloc((void**)&d_A, size_A);
-        cudaMalloc((void**)&d_B, size_B);
-        cudaMalloc((void**)&d_C, size_C);
-
-        cudaMemcpy(d_A, NDArray_FDATA(a), size_A, cudaMemcpyHostToDevice);
-        cudaMemcpy(d_B, NDArray_FDATA(b), size_B, cudaMemcpyHostToDevice);
+        cudaMalloc((void**)&deviceResult, sizeResult);
 
         int m = NDArray_SHAPE(a)[0];
         int n = NDArray_SHAPE(b)[1];
@@ -75,14 +65,11 @@ NDArray_FMatmul(NDArray *a, NDArray *b) {
         float alpha = 1.0f;
         float beta = 0.0f;
 
-        cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha, d_B, n, d_A, k, &beta, d_C, n);
-        cudaMemcpy(NDArray_FDATA(result), d_C, size_C, cudaMemcpyDeviceToHost);
+        cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha, NDArray_FDATA(b), n, NDArray_FDATA(a), k, &beta, deviceResult, n);
+        cudaMemcpy(NDArray_FDATA(result), deviceResult, sizeResult, cudaMemcpyDeviceToHost);
 
-        cudaFree(d_A);
-        cudaFree(d_B);
-        cudaFree(d_C);
+        cudaFree(deviceResult);
         cublasDestroy(handle);
-#endif
     } else {
         // Perform CPU matrix multiplication
         cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,

--- a/src/ndmath/linalg.c
+++ b/src/ndmath/linalg.c
@@ -51,6 +51,7 @@ NDArray_FMatmul(NDArray *a, NDArray *b) {
 
     if (NDArray_DEVICE(a) == NDARRAY_DEVICE_GPU) {
         // Perform GPU matrix multiplication
+#ifdef HAVE_CUBLAS
         cublasHandle_t handle;
         cublasCreate(&handle);
 
@@ -70,6 +71,7 @@ NDArray_FMatmul(NDArray *a, NDArray *b) {
 
         cudaFree(deviceResult);
         cublasDestroy(handle);
+#endif
     } else {
         // Perform CPU matrix multiplication
         cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,

--- a/src/ndmath/linalg.c
+++ b/src/ndmath/linalg.c
@@ -58,8 +58,7 @@ NDArray_FMatmul(NDArray *a, NDArray *b) {
         float* deviceResult;
         size_t sizeResult = NDArray_NUMELEMENTS(result) * sizeof(float);
 
-        cudaMalloc((void**)&deviceResult, sizeResult);
-
+        vmalloc((void**)&deviceResult, sizeResult);
         int m = NDArray_SHAPE(a)[0];
         int n = NDArray_SHAPE(b)[1];
         int k = NDArray_SHAPE(a)[1];
@@ -67,9 +66,8 @@ NDArray_FMatmul(NDArray *a, NDArray *b) {
         float beta = 0.0f;
 
         cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha, NDArray_FDATA(b), n, NDArray_FDATA(a), k, &beta, deviceResult, n);
-        cudaMemcpy(NDArray_FDATA(result), deviceResult, sizeResult, cudaMemcpyDeviceToHost);
-
-        cudaFree(deviceResult);
+        vfree(result->data);
+        result->data = (void*)deviceResult;
         cublasDestroy(handle);
 #endif
     } else {


### PR DESCRIPTION
### Overview

Firstly, by the time this code is executed, based on the NDArray_Matmul method, we know that both arrays are on the same device.

Based on the fact that we know that array "a" is on the GPU, we can say that both arrays are on the GPU. Therefore, the preprocessor directive to check for the presence of CUBLAS does not make sense, since placing the array in GPU memory is not possible without the presence of CUBLAS. Therefore this directive has been removed.

Secondly, based on the first point, we know that both arrays are already placed in GPU memory, therefore there is no need to allocate additional memory and copy them. Therefore, the cudaMalloc, cudaMemcpy and cudaFree functions for input arrays have been removed.

The name of the resulting array has been changed from d_C to deviceResult to make the code more clear.

These changes led to an increase in the performance of the matmul operation.

---

### Benchmark before changes:

#### NDArray

| Measurement        | Value              |
|--------------------|--------------------|
| Number of measurements | 100                |
| Mean               | 0.84835189755758    |
| Standard Deviation | 0.01839222232213   |

### Benchmark after changes:

#### NDArray

| Measurement        | Value              |
|--------------------|--------------------|
| Number of measurements | 100                |
| Mean               | 0.43721009731293    |
| Standard Deviation | 0.026118019744953   |

#### Pytorch (for comparison)

| Measurement        | Value              |
|--------------------|--------------------|
| Number of measurements | 100                |
| Mean               | 0.4293128824234    |
| Standard Deviation | 0.03115384458902   |

---

### Visualization of the multiplication rate as the number of iterations increases for NDArray and Pytorch.

![line-graph (1)](https://github.com/NumPower/numpower/assets/49936521/e0ee5e2b-790f-4301-a634-02a5b481071c)

**Note:** after the 50th iteration, the speed started to drop for both libraries. These performance changes correlate with the graphics card heating up.

**Test stand**
| #        | Value              |
|--------------------|--------------------|
| OS | Ubuntu                | 20.04
| PHP version               | 8.3.0    |
| NumPower version | 0.5.1   |
| Python version | 3.11.5   |
| Pytorch version | 2.2.0   |
| CUDA version | 11.6.2   |
| NVIDIA driver | 550.90   |
| GPU | GeForce GTX 980M 4Gb   |
| Matrix shape | 8192x8192   |
