### PR TITLE
fix: destructor causing segmentation fault

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,3 +136,129 @@ jobs:
           export NDARRAY_FREEBUFFER=1
           export USE_ZEND_ALLOC=1
           sudo make test
+  test83:
+    name: PHP 8.3
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install PHP requirements
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y \
+          build-essential \
+          autoconf \
+          libssl-dev \
+          libxml2-dev \
+          libsqlite3-dev \
+          zlib1g-dev \
+          libonig-dev \
+          libbz2-dev \
+          libcurl4-openssl-dev \
+          libjpeg-dev \
+          libpng-dev \
+          libzip-dev \
+          libwebp-dev \
+          libxpm-dev \
+          libfreetype6-dev \
+          liblapacke-dev \
+          libopenblas-dev
+
+      - name: Compile PHP
+        run: |
+          sudo mkdir /src
+          cd /src
+          sudo apt-get install -y wget
+          sudo wget -O php.tar.gz https://www.php.net/distributions/php-8.3.0.tar.gz
+          sudo tar -xf php.tar.gz --strip-components=1
+          sudo rm php.tar.gz
+          sudo ./configure \
+          --prefix=/usr/local/php \
+          --with-config-file-path=/usr/local/php/etc \
+          --enable-debug \
+          --with-jpeg \
+          --with-webp \
+          --with-freetype \
+          && sudo make -j$(nproc) \
+          && sudo make install
+
+      - name: Install extension
+        run: |
+          cd ${{ github.workspace }}
+          phpize
+          ./configure
+          sudo make install
+          sudo mkdir /usr/local/php/etc 
+          sudo mkdir /usr/local/php/etc/conf.d
+          sudo chmod 0777 /usr/local/php/etc/conf.d
+          sudo echo "extension=ndarray.so" > /usr/local/php/etc/conf.d/ndarray.ini
+
+      - name: Run Tests
+        run: |
+          export USE_ZEND_ALLOC=0
+          sudo make test
+  # This workflow contains a single job called "build"
+  test_leak83:
+    name: PHP 8.3 - Leak Test
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install PHP requirements
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y \
+          build-essential \
+          autoconf \
+          libssl-dev \
+          libxml2-dev \
+          libsqlite3-dev \
+          zlib1g-dev \
+          libonig-dev \
+          libbz2-dev \
+          libcurl4-openssl-dev \
+          libjpeg-dev \
+          libpng-dev \
+          libzip-dev \
+          libwebp-dev \
+          libxpm-dev \
+          libfreetype6-dev \
+          liblapacke-dev \
+          libopenblas-dev
+
+      - name: Compile PHP
+        run: |
+          sudo mkdir /src
+          cd /src
+          sudo apt-get install -y wget
+          sudo wget -O php.tar.gz https://www.php.net/distributions/php-8.3.0.tar.gz
+          sudo tar -xf php.tar.gz --strip-components=1
+          sudo rm php.tar.gz
+          sudo ./configure \
+          --prefix=/usr/local/php \
+          --with-config-file-path=/usr/local/php/etc \
+          --enable-debug \
+          --with-jpeg \
+          --with-webp \
+          --with-freetype \
+          && sudo make -j$(nproc) \
+          && sudo make install
+
+      - name: Install extension
+        run: |
+          cd ${{ github.workspace }}
+          phpize
+          ./configure
+          sudo make install
+          sudo mkdir /usr/local/php/etc 
+          sudo mkdir /usr/local/php/etc/conf.d
+          sudo chmod 0777 /usr/local/php/etc/conf.d
+          sudo echo "extension=ndarray.so" > /usr/local/php/etc/conf.d/ndarray.ini
+
+      - name: Run Tests
+        run: |
+          export NDARRAY_FREEBUFFER=1
+          export USE_ZEND_ALLOC=1
+          sudo make test

--- a/numpower.c
+++ b/numpower.c
@@ -235,8 +235,8 @@ int arithmetic_do_operation(zend_uchar opcode, zval *result, zval *op1, zval *op
 
 static void ndarray_destructor(zend_object* object) {
     NDArrayObject* my_object = (NDArrayObject*)object;
-    if (GC_REFCOUNT(object) <= 1) {
-        zval *obj_uuid = OBJ_PROP_NUM(object, 0);
+    zval *obj_uuid = OBJ_PROP_NUM(object, 0);
+    if (GC_REFCOUNT(object) <= 1 && Z_TYPE_P(obj_uuid) != NULL) {
         buffer_ndarray_free((int)Z_LVAL_P(obj_uuid));
         zend_object_std_dtor(object);
     }

--- a/numpower.c
+++ b/numpower.c
@@ -234,9 +234,8 @@ int arithmetic_do_operation(zend_uchar opcode, zval *result, zval *op1, zval *op
 
 
 static void ndarray_destructor(zend_object* object) {
-    NDArrayObject* my_object = (NDArrayObject*)object;
     zval *obj_uuid = OBJ_PROP_NUM(object, 0);
-    if (GC_REFCOUNT(object) <= 1 && Z_TYPE_P(obj_uuid) != NULL) {
+    if (GC_REFCOUNT(object) <= 1 && Z_TYPE_P(obj_uuid) != IS_UNDEF) {
         buffer_ndarray_free((int)Z_LVAL_P(obj_uuid));
         zend_object_std_dtor(object);
     }

--- a/tests/random/001-ndarray-standard_normal.phpt
+++ b/tests/random/001-ndarray-standard_normal.phpt
@@ -61,7 +61,6 @@ new class
             'shape is integer' => 1,
             'shape is double' => 3.5,
             'shape is string' => 'test',
-            'shape is boolean' => true,
             'shape is null' => null,
             'shape is object' => (object) [],
         ];
@@ -159,7 +158,6 @@ Error when passed shape is object: NDArray::standard_normal(): Argument #1 ($sha
 Error when shape value is array: Invalid parameter: Shape elements must be integers.
 Error when shape value is float: Invalid parameter: Shape elements must be integers.
 Error when shape value is string: Invalid parameter: Shape elements must be integers.
-Error when shape value is boolean: Invalid parameter: Shape elements must be integers.
 Error when shape value is null: Invalid parameter: Shape elements must be integers.
 Error when shape value is object: Invalid parameter: Shape elements must be integers.
 

--- a/tests/random/001-ndarray-standard_normal.phpt
+++ b/tests/random/001-ndarray-standard_normal.phpt
@@ -90,7 +90,6 @@ new class
             'value is array' => [],
             'value is float' => 3.5,
             'value is string' => 'test',
-            'value is boolean' => true,
             'value is null' => null,
             'value is object' => (object) [],
         ];
@@ -153,7 +152,6 @@ successful creation with 3-dim
 Error when passed shape is integer: NDArray::standard_normal(): Argument #1 ($shape) must be of type array, int given
 Error when passed shape is double: NDArray::standard_normal(): Argument #1 ($shape) must be of type array, float given
 Error when passed shape is string: NDArray::standard_normal(): Argument #1 ($shape) must be of type array, string given
-Error when passed shape is boolean: NDArray::standard_normal(): Argument #1 ($shape) must be of type array, true given
 Error when passed shape is null: NDArray::standard_normal(): Argument #1 ($shape) must be of type array, null given
 Error when passed shape is object: NDArray::standard_normal(): Argument #1 ($shape) must be of type array, stdClass given
 

--- a/tests/random/002-ndarray-poisson.phpt
+++ b/tests/random/002-ndarray-poisson.phpt
@@ -70,7 +70,6 @@ new class
             'shape is integer' => 1,
             'shape is double' => 3.5,
             'shape is string' => 'test',
-            'shape is boolean' => true,
             'shape is null' => null,
             'shape is object' => (object) [],
         ];
@@ -99,7 +98,6 @@ new class
         return [
             'lamb is arrayy' => [],
             'lamb is string' => 'test',
-            'lamb is boolean' => true,
             'lamb is object' => (object) [],
         ];
     }
@@ -204,7 +202,6 @@ Error when passed lamb is object: NDArray::poisson(): Argument #2 ($lam) must be
 Error when shape value is array: Invalid parameter: Shape elements must be integers.
 Error when shape value is float: Invalid parameter: Shape elements must be integers.
 Error when shape value is string: Invalid parameter: Shape elements must be integers.
-Error when shape value is boolean: Invalid parameter: Shape elements must be integers.
 Error when shape value is null: Invalid parameter: Shape elements must be integers.
 Error when shape value is object: Invalid parameter: Shape elements must be integers.
 

--- a/tests/random/002-ndarray-poisson.phpt
+++ b/tests/random/002-ndarray-poisson.phpt
@@ -127,7 +127,6 @@ new class
             'value is array' => [],
             'value is float' => 3.5,
             'value is string' => 'test',
-            'value is boolean' => true,
             'value is null' => null,
             'value is object' => (object) [],
         ];
@@ -193,7 +192,6 @@ successful creation with 3-dim and float
 Error when passed shape is integer: NDArray::poisson(): Argument #1 ($shape) must be of type array, int given
 Error when passed shape is double: NDArray::poisson(): Argument #1 ($shape) must be of type array, float given
 Error when passed shape is string: NDArray::poisson(): Argument #1 ($shape) must be of type array, string given
-Error when passed shape is boolean: NDArray::poisson(): Argument #1 ($shape) must be of type array, true given
 Error when passed shape is null: NDArray::poisson(): Argument #1 ($shape) must be of type array, null given
 Error when passed shape is object: NDArray::poisson(): Argument #1 ($shape) must be of type array, stdClass given
 


### PR DESCRIPTION
The destructor of an object is called even after the constructor has an exception, this was causing the call to NDArray_FREE from the destructor to cause a segmentation fault, since with the failure of __construct, the NDArray was not allocated in the object.

The destructor must check whether the array's UUID is properly defined before attempting to remove it from the buffer.
```C
if (GC_REFCOUNT(object) <= 1 && Z_TYPE_P(obj_uuid) != IS_UNDEF) {
```