### PR TITLE
fix: segmentation fault with empty arrays initialization and __toString magic method

### DIFF
--- a/numpower.c
+++ b/numpower.c
@@ -4364,7 +4364,7 @@ PHP_METHOD(NDArray, array) {
     zval *a;
     long axis;
     ZEND_PARSE_PARAMETERS_START(1, 1)
-    Z_PARAM_ZVAL(a)
+        Z_PARAM_ZVAL(a)
     ZEND_PARSE_PARAMETERS_END();
     NDArray *nda = ZVAL_TO_NDARRAY(a);
     if (nda == NULL) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -59,6 +59,13 @@ print_array_float(float* buffer, int ndims, int* shape, int* strides, int cur_di
     char* str;
     int i, j, t;
     int reverse_run = 0;
+
+    if (num_elements == 0) {
+        str = (char*)emalloc(3 * sizeof(char));
+        str = "[]";
+        return str;
+    }
+
     // Allocate memory for the string
     str = (char*)emalloc(10000000 * sizeof(char));
     if (str == NULL) {
@@ -177,7 +184,7 @@ print_array_float(float* buffer, int ndims, int* shape, int* strides, int cur_di
 }
 
 /**
- * Print matrix to
+ * Print matrix of type float32
  *
  * @param buffer
  * @param ndims

--- a/src/initializers.c
+++ b/src/initializers.c
@@ -80,7 +80,7 @@ int get_num_dims_from_zval(zval *arr) {
     int num_dims = 0;
 
     if (zend_array_count(Z_ARRVAL_P(arr)) == 0) {
-        return 0;
+        return 1;
     }
 
     zval *val = zend_hash_index_find(Z_ARRVAL_P(arr), 0);
@@ -207,9 +207,9 @@ NDArray* Create_NDArray_FromZendArray(zend_array* ht, int ndim) {
     int last_index = 0;
     int *shape;
     if (ndim != 0) {
-        shape = emalloc(ndim * sizeof(int));
+        shape = ecalloc(ndim, sizeof(int));
     } else {
-        shape = emalloc(1 * sizeof(int));
+        shape = ecalloc(1, sizeof(int));
     }
     if (!is_packed_zend_array(ht)) {
         return NULL;

--- a/tests/initializers/001-ndarray-array-phparray.phpt
+++ b/tests/initializers/001-ndarray-array-phparray.phpt
@@ -4,6 +4,12 @@ NDArray::array
 <?php
 $a = \NDArray::array([[1, 2], [3, 4]]);
 print_r($a->toArray());
+$a = \NDArray::array([]);
+print_r($a->toArray());
+$a = new \NDArray([[1, 2], [3, 4]]);
+print_r($a->toArray());
+$a = new \NDArray([]);
+print_r($a->toArray());
 ?>
 --EXPECT--
 Array
@@ -20,4 +26,25 @@ Array
             [1] => 4
         )
 
+)
+Array
+(
+)
+Array
+(
+    [0] => Array
+        (
+            [0] => 1
+            [1] => 2
+        )
+
+    [1] => Array
+        (
+            [0] => 3
+            [1] => 4
+        )
+
+)
+Array
+(
 )


### PR DESCRIPTION
Fixed an issue where initializing empty ndarrays caused segmentation errors:

```php
$a = nd::array([]);
```
Results:
```
Segmentation fault (core dumped)
```

This also prepares the methods `print_r` (__toString) and toArray to use empty arrays. With this MR the code below will succefully execute:

```php
$a = nd::array([]);
$a->dump();
print_r($a);
echo $a;
print_r($a->toArray());
```

## __toString segmentation fault

The __toString method was incorrectly freeing memory and causing segmentation fault when trying to read an array using echo. 

```C
PHP_METHOD(NDArray, __toString) {
    ...
    char *result = NDArray_Print(ndarray, 1);
    RETVAL_STRING(result);
    efree(result); << caused segfault
}
```
