### PR TITLE
New methods and features for 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,23 @@ NumPower aims to manage memory more efficiently than a matrix in PHP arrays
 - **Optional (GPU)**: CUBLAS, CUDA Build Toolkit and cuDNN
 - **Optional (Image)**: PHP-GD
 
-## Composer Install
+## Compiling
+
+``` 
+$ phpize
+$ ./configure
+$ make install
+```
+
+## Compiling with GPU (CUDA) support
+
+``` 
+$ phpize
+$ ./configure --with-cuda
+$ make install-cuda
+```
+
+## Composer install
 The composer package provides a stubs file to facilitate autocomplete in the IDE. To install, simply run the command below in your environment with composer installed:
 
 ```bash
@@ -42,7 +58,7 @@ $ composer require numpower/numpower
 
 The composer package will follow the same versioning as the extension.
 
-## GPU Support
+## GPU support
 
 If you have an NVIDIA graphics card with CUDA support, you can use your graphics card 
 to perform operations. To do this, just copy your array to the GPU memory.

--- a/numpower.c
+++ b/numpower.c
@@ -3637,6 +3637,39 @@ PHP_METHOD(NDArray, swapaxes) {
 }
 
 /**
+* NDArray::rollaxis
+*/
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_rollaxis, 0, 0, 2)
+    ZEND_ARG_INFO(0, a)
+    ZEND_ARG_INFO(0, axis)
+    ZEND_ARG_INFO(0, start)
+ZEND_END_ARG_INFO()
+PHP_METHOD(NDArray, rollaxis) {
+    NDArray *rtn = NULL;
+    zval *a;
+    long axis, start = 0;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_ZVAL(a)
+        Z_PARAM_LONG(axis)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(start)
+    ZEND_PARSE_PARAMETERS_END();
+
+    NDArray *nda = ZVAL_TO_NDARRAY(a);
+    if (nda == NULL) {
+    return;
+    }
+
+    rtn = NDArray_Rollaxis(nda, (int) axis, (int) start);
+
+    CHECK_INPUT_AND_FREE(a, nda);
+    if (rtn == NULL) {
+    return;
+    }
+    RETURN_NDARRAY(rtn, return_value);
+}
+
+/**
  * NDArray::append
  */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_append, 0, 0, 1)
@@ -4811,6 +4844,7 @@ static const zend_function_entry class_NDArray_methods[] = {
     ZEND_ME(NDArray, squeeze, arginfo_ndarray_squeeze, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, flip, arginfo_ndarray_flip, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, swapaxes, arginfo_ndarray_swapaxes, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    ZEND_ME(NDArray, rollaxis, arginfo_ndarray_rollaxis, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 
     // INDEXING
     ZEND_ME(NDArray, diagonal, arginfo_ndarray_diagonal, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/numpower.c
+++ b/numpower.c
@@ -1100,7 +1100,7 @@ PHP_METHOD(NDArray, diag) {
     NDArray *rtn = NULL;
     zval* target;
     ZEND_PARSE_PARAMETERS_START(1, 1)
-    Z_PARAM_ZVAL(target)
+        Z_PARAM_ZVAL(target)
     ZEND_PARSE_PARAMETERS_END();
     NDArray *nda = ZVAL_TO_NDARRAY(target);
     if (nda == NULL)  return;
@@ -3429,7 +3429,7 @@ PHP_METHOD(NDArray, expand_dims) {
 /**
 * NDArray::squeeze
 */
-ZEND_BEGIN_ARG_INFO(arginfo_ndarray_squeeze, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_squeeze, 0, 0, 1)
     ZEND_ARG_INFO(0, a)
     ZEND_ARG_INFO(0, axis)
 ZEND_END_ARG_INFO()
@@ -3438,9 +3438,9 @@ PHP_METHOD(NDArray, squeeze) {
     zval *a;
     zval *axis;
     ZEND_PARSE_PARAMETERS_START(1, 2)
-            Z_PARAM_ZVAL(a)
-            Z_PARAM_OPTIONAL
-            Z_PARAM_ZVAL(axis)
+        Z_PARAM_ZVAL(a)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ZVAL(axis)
     ZEND_PARSE_PARAMETERS_END();
 
     if (Z_TYPE_P(axis) != IS_ARRAY && Z_TYPE_P(axis) != IS_LONG && Z_TYPE_P(axis) != IS_OBJECT && ZEND_NUM_ARGS() > 1) {
@@ -3466,7 +3466,7 @@ PHP_METHOD(NDArray, squeeze) {
 /**
 * NDArray::flip
 */
-ZEND_BEGIN_ARG_INFO(arginfo_ndarray_flip, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_flip, 0, 0, 1)
     ZEND_ARG_INFO(0, a)
     ZEND_ARG_INFO(0, axis)
 ZEND_END_ARG_INFO()
@@ -4671,6 +4671,7 @@ static const zend_function_entry class_NDArray_methods[] = {
     ZEND_ME(NDArray, append, arginfo_ndarray_append, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, expand_dims, arginfo_ndarray_expand_dims, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, squeeze, arginfo_ndarray_squeeze, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    ZEND_ME(NDArray, flip, arginfo_ndarray_flip, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 
     // INDEXING
     ZEND_ME(NDArray, diagonal, arginfo_ndarray_diagonal, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/numpower.c
+++ b/numpower.c
@@ -3900,42 +3900,35 @@ PHP_METHOD(NDArray, concatenate) {
 /**
  * NDArray::append
  */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_append, 0, 0, 1)
-ZEND_ARG_INFO(0, arrays)
-ZEND_ARG_INFO(0, axis)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_append, 0, 0, 2)
+    ZEND_ARG_INFO(0, array)
+    ZEND_ARG_INFO(0, values)
+    ZEND_ARG_INFO(0, axis)
 ZEND_END_ARG_INFO()
-PHP_METHOD(NDArray, append) {
+    PHP_METHOD(NDArray, append) {
     NDArray *rtn = NULL;
-    zval *arrays;
-    long axis;
-    ZEND_PARSE_PARAMETERS_START(1, 2)
-        Z_PARAM_ARRAY(arrays)
+    int num_args;
+    zval *axis = NULL, *array, *values;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_ZVAL(array)
+        Z_PARAM_ZVAL(values)
         Z_PARAM_OPTIONAL
-        Z_PARAM_LONG(axis)
+        Z_PARAM_ZVAL(axis)
     ZEND_PARSE_PARAMETERS_END();
 
-    HashTable *ht = Z_ARRVAL_P(arrays);
-    zval* arr_val;
-    NDArray **ndarrays = emalloc(sizeof(NDArray*) * 128);
-    zval **input_zvals = emalloc(sizeof(zval*) * 128);
-    int num_arrays = 0;
-    ZEND_HASH_FOREACH_VAL(ht, arr_val) {
-        ndarrays[num_arrays] = ZVAL_TO_NDARRAY(arr_val);
-                input_zvals[num_arrays] = arr_val;
-        if (ndarrays[num_arrays] == NULL) {
-            goto fail;
-        }
-        num_arrays++;
-    } ZEND_HASH_FOREACH_END();
-    rtn = NDArray_Append(ndarrays, -1, num_arrays);
+    NDArray **ndarrays = (NDArray**)emalloc(sizeof(NDArray*) * 2);
+    ndarrays[0] = ZVAL_TO_NDARRAY(array);
+    ndarrays[1] = ZVAL_TO_NDARRAY(values);
+    num_args = 2;
+    if (ndarrays == NULL) return;
 
-    for (int i = 0; i < num_arrays; i++) {
-        CHECK_INPUT_AND_FREE(input_zvals[i], ndarrays[i]);
+    if (ZEND_NUM_ARGS() == 2) {
+        rtn = NDArray_ConcatenateFlat(ndarrays, num_args);
+    } else {
+        rtn = NDArray_Concatenate(ndarrays, num_args, zval_get_long(axis));
     }
-    RETURN_NDARRAY(rtn, return_value);
-fail:
-    efree(input_zvals);
     efree(ndarrays);
+    RETURN_NDARRAY(rtn, return_value);
 }
 
 /**

--- a/numpower.c
+++ b/numpower.c
@@ -2285,6 +2285,41 @@ PHP_METHOD(NDArray, negative) {
 }
 
 /**
+ * NDArray::positive
+ *
+ * @param execute_data
+ * @param return_value
+ */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_positive, 0, 0, 1)
+    ZEND_ARG_INFO(0, array)
+ZEND_END_ARG_INFO()
+PHP_METHOD(NDArray, positive) {
+    NDArray *rtn = NULL;
+    zval *array;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ZVAL(array)
+    ZEND_PARSE_PARAMETERS_END();
+    NDArray *nda = ZVAL_TO_NDARRAY(array);
+    if (nda == NULL) {
+        return;
+    }
+
+    if (NDArray_DEVICE(nda) == NDARRAY_DEVICE_CPU) {
+        rtn = NDArray_Map(nda, float_positive);
+    } else {
+#ifdef HAVE_CUBLAS
+        rtn = NDArrayMathGPU_ElementWise(nda, cuda_float_positive);
+#else
+        zend_throw_error(NULL, "GPU operations unavailable. CUBLAS not detected.");
+#endif
+    }
+    if (Z_TYPE_P(array) == IS_ARRAY) {
+        NDArray_FREE(nda);
+    }
+    RETURN_NDARRAY(rtn, return_value);
+}
+
+/**
  * NDArray::sign
  *
  * @param execute_data
@@ -4784,6 +4819,7 @@ static const zend_function_entry class_NDArray_methods[] = {
     ZEND_ME(NDArray, trunc, arginfo_ndarray_trunc, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, sinc, arginfo_ndarray_sinc, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, negative, arginfo_ndarray_negative, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    ZEND_ME(NDArray, positive, arginfo_ndarray_positive, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, sign, arginfo_ndarray_sign, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, clip, arginfo_ndarray_clip, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, round, arginfo_ndarray_round, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/numpower.c
+++ b/numpower.c
@@ -2320,6 +2320,42 @@ PHP_METHOD(NDArray, positive) {
 }
 
 /**
+ * NDArray::reciprocal
+ *
+ * @param execute_data
+ * @param return_value
+ */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_reciprocal, 0, 0, 1)
+    ZEND_ARG_INFO(0, array)
+ZEND_END_ARG_INFO()
+PHP_METHOD(NDArray, reciprocal) {
+    NDArray *rtn = NULL;
+    zval *array;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ZVAL(array)
+    ZEND_PARSE_PARAMETERS_END();
+    NDArray *nda = ZVAL_TO_NDARRAY(array);
+    if (nda == NULL) {
+        return;
+    }
+
+    if (NDArray_DEVICE(nda) == NDARRAY_DEVICE_CPU) {
+        rtn = NDArray_Map(nda, float_reciprocal);
+    } else {
+#ifdef HAVE_CUBLAS
+        rtn = NDArrayMathGPU_ElementWise(nda, cuda_float_reciprocal);
+#else
+        zend_throw_error(NULL, "GPU operations unavailable. CUBLAS not detected.");
+#endif
+    }
+    if (Z_TYPE_P(array) == IS_ARRAY) {
+        NDArray_FREE(nda);
+    }
+    RETURN_NDARRAY(rtn, return_value);
+}
+
+
+/**
  * NDArray::sign
  *
  * @param execute_data
@@ -4824,6 +4860,7 @@ static const zend_function_entry class_NDArray_methods[] = {
     ZEND_ME(NDArray, clip, arginfo_ndarray_clip, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, round, arginfo_ndarray_round, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, rsqrt, arginfo_ndarray_rsqrt, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    ZEND_ME(NDArray, reciprocal, arginfo_ndarray_reciprocal, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 
     // STATISTICS
     ZEND_ME(NDArray, mean, arginfo_ndarray_mean, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/numpower.c
+++ b/numpower.c
@@ -3927,6 +3927,8 @@ ZEND_END_ARG_INFO()
     } else {
         rtn = NDArray_Concatenate(ndarrays, num_args, zval_get_long(axis));
     }
+    CHECK_INPUT_AND_FREE(array, ndarrays[0]);
+    CHECK_INPUT_AND_FREE(values, ndarrays[1]);
     efree(ndarrays);
     RETURN_NDARRAY(rtn, return_value);
 }

--- a/numpower.c
+++ b/numpower.c
@@ -2437,13 +2437,17 @@ PHP_METHOD(NDArray, argmax) {
     NDArray *rtn = NULL;
     zval *a;
     long axis;
-    ZEND_PARSE_PARAMETERS_START(2, 2)
+    ZEND_PARSE_PARAMETERS_START(1, 2)
         Z_PARAM_ZVAL(a)
+        Z_PARAM_OPTIONAL
         Z_PARAM_LONG(axis)
     ZEND_PARSE_PARAMETERS_END();
     NDArray *nda = ZVAL_TO_NDARRAY(a);
     if (nda == NULL) {
         return;
+    }
+    if (ZEND_NUM_ARGS() == 1) {
+        axis = 128;
     }
     rtn = NDArray_ArgMinMaxCommon(nda, (int)axis, 0, 1);
     if (rtn == NULL) return;
@@ -2465,13 +2469,17 @@ PHP_METHOD(NDArray, argmin) {
     NDArray *rtn = NULL;
     zval *a;
     long axis;
-    ZEND_PARSE_PARAMETERS_START(2, 2)
+    ZEND_PARSE_PARAMETERS_START(1, 2)
         Z_PARAM_ZVAL(a)
+        Z_PARAM_OPTIONAL
         Z_PARAM_LONG(axis)
     ZEND_PARSE_PARAMETERS_END();
     NDArray *nda = ZVAL_TO_NDARRAY(a);
     if (nda == NULL) {
         return;
+    }
+    if (ZEND_NUM_ARGS() == 1) {
+        axis = 128;
     }
     rtn = NDArray_ArgMinMaxCommon(nda, (int)axis, 0, 0);
     if (rtn == NULL) return;

--- a/numpower.c
+++ b/numpower.c
@@ -3816,7 +3816,7 @@ PHP_METHOD(NDArray, hstack) {
 * NDArray::dstack
 */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_dstack, 0, 0, 1)
-    ZEND_ARG_INFO(0, a)
+    ZEND_ARG_INFO(0, arrays)
 ZEND_END_ARG_INFO()
 PHP_METHOD(NDArray, dstack) {
     NDArray *rtn = NULL;
@@ -3828,6 +3828,30 @@ PHP_METHOD(NDArray, dstack) {
     NDArray **ndarrays = ARRAY_OF_NDARRAYS(arrays, &num_args);
     if (ndarrays == NULL) return;
     rtn = NDArray_DSTACK(ndarrays, num_args);
+
+    for (int i = 0; i < num_args; i++) {
+        NDArray_FREE(ndarrays[i]);
+    }
+    efree(ndarrays);
+    RETURN_NDARRAY(rtn, return_value);
+}
+
+/**
+* NDArray::column_stack
+*/
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_column_stack, 0, 0, 1)
+    ZEND_ARG_INFO(0, a)
+ZEND_END_ARG_INFO()
+PHP_METHOD(NDArray, column_stack) {
+    NDArray *rtn = NULL;
+    zval *arrays;
+    int num_args;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ARRAY(arrays)
+    ZEND_PARSE_PARAMETERS_END();
+    NDArray **ndarrays = ARRAY_OF_NDARRAYS(arrays, &num_args);
+    if (ndarrays == NULL) return;
+    rtn = NDArray_ColumnStack(ndarrays, num_args);
 
     for (int i = 0; i < num_args; i++) {
         NDArray_FREE(ndarrays[i]);
@@ -5016,6 +5040,7 @@ static const zend_function_entry class_NDArray_methods[] = {
     ZEND_ME(NDArray, vstack, arginfo_ndarray_vstack, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, hstack, arginfo_ndarray_hstack, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_ME(NDArray, dstack, arginfo_ndarray_dstack, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    ZEND_ME(NDArray, column_stack, arginfo_ndarray_column_stack, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 
     // INDEXING
     ZEND_ME(NDArray, diagonal, arginfo_ndarray_diagonal, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/numpower.c
+++ b/numpower.c
@@ -2512,15 +2512,18 @@ PHP_METHOD(NDArray, minimum) {
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_argmax, 0, 0, 1)
     ZEND_ARG_INFO(0, a)
     ZEND_ARG_INFO(0, axis)
+    ZEND_ARG_INFO(0, keepdims)
 ZEND_END_ARG_INFO()
 PHP_METHOD(NDArray, argmax) {
     NDArray *rtn = NULL;
     zval *a;
     long axis;
-    ZEND_PARSE_PARAMETERS_START(1, 2)
+    bool keepdims = false;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
         Z_PARAM_ZVAL(a)
         Z_PARAM_OPTIONAL
         Z_PARAM_LONG(axis)
+        Z_PARAM_BOOL(keepdims)
     ZEND_PARSE_PARAMETERS_END();
     NDArray *nda = ZVAL_TO_NDARRAY(a);
     if (nda == NULL) {
@@ -2529,7 +2532,7 @@ PHP_METHOD(NDArray, argmax) {
     if (ZEND_NUM_ARGS() == 1) {
         axis = 128;
     }
-    rtn = NDArray_ArgMinMaxCommon(nda, (int)axis, 0, 1);
+    rtn = NDArray_ArgMinMaxCommon(nda, (int)axis, keepdims, true);
     if (rtn == NULL) return;
     CHECK_INPUT_AND_FREE(a, nda);
     RETURN_NDARRAY(rtn, return_value);
@@ -2542,17 +2545,20 @@ PHP_METHOD(NDArray, argmax) {
  * @param return_value
  */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ndarray_argmin, 0, 0, 1)
-        ZEND_ARG_INFO(0, a)
-        ZEND_ARG_INFO(0, axis)
+    ZEND_ARG_INFO(0, a)
+    ZEND_ARG_INFO(0, axis)
+    ZEND_ARG_INFO(0, keepdims)
 ZEND_END_ARG_INFO()
 PHP_METHOD(NDArray, argmin) {
     NDArray *rtn = NULL;
     zval *a;
     long axis;
-    ZEND_PARSE_PARAMETERS_START(1, 2)
+    bool keepdims = false;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
         Z_PARAM_ZVAL(a)
         Z_PARAM_OPTIONAL
         Z_PARAM_LONG(axis)
+        Z_PARAM_BOOL(keepdims)
     ZEND_PARSE_PARAMETERS_END();
     NDArray *nda = ZVAL_TO_NDARRAY(a);
     if (nda == NULL) {
@@ -2561,7 +2567,7 @@ PHP_METHOD(NDArray, argmin) {
     if (ZEND_NUM_ARGS() == 1) {
         axis = 128;
     }
-    rtn = NDArray_ArgMinMaxCommon(nda, (int)axis, 0, 0);
+    rtn = NDArray_ArgMinMaxCommon(nda, (int)axis, keepdims, false);
     if (rtn == NULL) return;
     CHECK_INPUT_AND_FREE(a, nda);
     RETURN_NDARRAY(rtn, return_value);

--- a/php_numpower.h
+++ b/php_numpower.h
@@ -64,7 +64,7 @@ ZEND_FUNCTION(print_r_);
 PHPAPI zend_class_entry *phpsci_ce_NDArray;
 PHPAPI zend_class_entry *phpsci_ce_ArithmeticOperand;
 
-# define PHP_NDARRAY_VERSION "0.5.2"
+# define PHP_NDARRAY_VERSION "0.6.0"
 
 # if defined(ZTS) && defined(COMPILE_DL_NDARRAY)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/src/dnn.c
+++ b/src/dnn.c
@@ -338,7 +338,7 @@ NDArrayDNN_Conv2D_Backward(NDArray *input, NDArray *y, NDArray *filters, int ker
         rtn_temp = NDArray_Empty(output_shape_dw, 4, NDArray_TYPE(input), NDArray_DEVICE(input));
         NDArray_FREEDATA(rtn_temp);
         rtn_temp->data = (void*)outputs[0];
-        rtn_dw = NDArray_Transpose(rtn_temp);
+        rtn_dw = NDArray_Transpose(rtn_temp, NULL);
         NDArray_FREE(rtn_temp);
 
         // Build dW

--- a/src/iterators.c
+++ b/src/iterators.c
@@ -157,3 +157,112 @@ NDArray_NewElementWiseIter(NDArray *target) {
     return it;
 }
 
+int
+NDArray_PrepareTwoRawArrayIter(int ndim, int const *shape,
+                               char *dataA, int const *stridesA,
+                               char *dataB, int const *stridesB,
+                               int *out_ndim, int *out_shape,
+                               char **out_dataA, int *out_stridesA,
+                               char **out_dataB, int *out_stridesB)
+{
+    ndarray_stride_sort_item strideperm[NDARRAY_MAX_DIMS];
+    int i, j;
+
+    /* Special case 0 and 1 dimensions */
+    if (ndim == 0) {
+        *out_ndim = 1;
+        *out_dataA = dataA;
+        *out_dataB = dataB;
+        out_shape[0] = 1;
+        out_stridesA[0] = 0;
+        out_stridesB[0] = 0;
+        return 0;
+    }
+    else if (ndim == 1) {
+        int stride_entryA = stridesA[0], stride_entryB = stridesB[0];
+        int shape_entry = shape[0];
+        *out_ndim = 1;
+        out_shape[0] = shape[0];
+        /* Always make a positive stride for the first operand */
+        if (stride_entryA >= 0) {
+            *out_dataA = dataA;
+            *out_dataB = dataB;
+            out_stridesA[0] = stride_entryA;
+            out_stridesB[0] = stride_entryB;
+        }
+        else {
+            *out_dataA = dataA + stride_entryA * (shape_entry - 1);
+            *out_dataB = dataB + stride_entryB * (shape_entry - 1);
+            out_stridesA[0] = -stride_entryA;
+            out_stridesB[0] = -stride_entryB;
+        }
+        return 0;
+    }
+
+    /* Sort the axes based on the destination strides */
+    NDArray_CreateSortedStridePerm(ndim, stridesA, strideperm);
+    for (i = 0; i < ndim; ++i) {
+        int iperm = strideperm[ndim - i - 1].perm;
+        out_shape[i] = shape[iperm];
+        out_stridesA[i] = stridesA[iperm];
+        out_stridesB[i] = stridesB[iperm];
+    }
+
+    /* Reverse any negative strides of operand A */
+    for (i = 0; i < ndim; ++i) {
+        int stride_entryA = out_stridesA[i];
+        int stride_entryB = out_stridesB[i];
+        int shape_entry = out_shape[i];
+
+        if (stride_entryA < 0) {
+            dataA += stride_entryA * (shape_entry - 1);
+            dataB += stride_entryB * (shape_entry - 1);
+            out_stridesA[i] = -stride_entryA;
+            out_stridesB[i] = -stride_entryB;
+        }
+        /* Detect 0-size arrays here */
+        if (shape_entry == 0) {
+            *out_ndim = 1;
+            *out_dataA = dataA;
+            *out_dataB = dataB;
+            out_shape[0] = 0;
+            out_stridesA[0] = 0;
+            out_stridesB[0] = 0;
+            return 0;
+        }
+    }
+
+    /* Coalesce any dimensions where possible */
+    i = 0;
+    for (j = 1; j < ndim; ++j) {
+        if (out_shape[i] == 1) {
+            /* Drop axis i */
+            out_shape[i] = out_shape[j];
+            out_stridesA[i] = out_stridesA[j];
+            out_stridesB[i] = out_stridesB[j];
+        }
+        else if (out_shape[j] == 1) {
+            /* Drop axis j */
+        }
+        else if (out_stridesA[i] * out_shape[i] == out_stridesA[j] &&
+                 out_stridesB[i] * out_shape[i] == out_stridesB[j]) {
+            /* Coalesce axes i and j */
+            out_shape[i] *= out_shape[j];
+        }
+        else {
+            /* Can't coalesce, go to next i */
+            ++i;
+            out_shape[i] = out_shape[j];
+            out_stridesA[i] = out_stridesA[j];
+            out_stridesB[i] = out_stridesB[j];
+        }
+    }
+    ndim = i+1;
+
+    *out_dataA = dataA;
+    *out_dataB = dataB;
+    *out_ndim = ndim;
+    return 0;
+}
+
+

--- a/src/iterators.h
+++ b/src/iterators.h
@@ -32,6 +32,12 @@ int NDArrayIteratorPHP_ISDONE(NDArray* array);
 void NDArrayIteratorPHP_NEXT(NDArray* array);
 
 NDArrayIter* NDArray_NewElementWiseIter(NDArray *target);
+int NDArray_PrepareTwoRawArrayIter(int ndim, int const *shape,
+                               char *dataA, int const *stridesA,
+                               char *dataB, int const *stridesB,
+                               int *out_ndim, int *out_shape,
+                               char **out_dataA, int *out_stridesA,
+                               char **out_dataB, int *out_stridesB);
 
 #define _NDArray_ITER_NEXT1(it) do { \
         (it)->dataptr += (it)->strides[0]; \
@@ -86,4 +92,38 @@ NDArrayIter* NDArray_NewElementWiseIter(NDArray *target);
                 } \
         } \
 } while (0)
+
+
+#define NDARRAY_RAW_ITER_START(idim, ndim, coord, shape) \
+        memset((coord), 0, (ndim) * sizeof(coord[0]));   \
+        do {
+
+#define NDARRAY_RAW_ITER_ONE_NEXT(idim, ndim, coord, shape, data, strides) \
+            for ((idim) = 1; (idim) < (ndim); ++(idim)) { \
+                if (++(coord)[idim] == (shape)[idim]) { \
+                    (coord)[idim] = 0; \
+                    (data) -= ((shape)[idim] - 1) * (strides)[idim]; \
+                } \
+                else { \
+                    (data) += (strides)[idim]; \
+                    break; \
+                } \
+            } \
+        } while ((idim) < (ndim))
+
+#define NDARRAY_RAW_ITER_TWO_NEXT(idim, ndim, coord, shape, \
+                              dataA, stridesA, dataB, stridesB) \
+            for ((idim) = 1; (idim) < (ndim); ++(idim)) { \
+                if (++(coord)[idim] == (shape)[idim]) { \
+                    (coord)[idim] = 0; \
+                    (dataA) -= ((shape)[idim] - 1) * (stridesA)[idim]; \
+                    (dataB) -= ((shape)[idim] - 1) * (stridesB)[idim]; \
+                } \
+                else { \
+                    (dataA) += (stridesA)[idim]; \
+                    (dataB) += (stridesB)[idim]; \
+                    break; \
+                } \
+            } \
+        } while ((idim) < (ndim))
 #endif //PHPSCI_NDARRAY_ITERATORS_H

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -1026,6 +1026,27 @@ NDArray_DSTACK(NDArray **arrays, int narrays)
 }
 
 NDArray*
+NDArray_ColumnStack(NDArray **arrays, int narrays)
+{
+    NDArray *tmp;
+    NDArray **parsed_arrays = emalloc(sizeof(NDArray*) * narrays);
+    for (int i = 0; i < narrays; i++) {
+        tmp = NDArray_AtLeast2D(arrays[i]);
+        parsed_arrays[i] = NDArray_Transpose(tmp, NULL);
+        NDArray_FREE(tmp);
+    }
+
+    NDArray * result = NULL;
+    result = NDArray_Concatenate(parsed_arrays, narrays, 1);
+
+    for (int i = 0; i < narrays; i++) {
+        NDArray_FREE(parsed_arrays[i]);
+    }
+    efree(parsed_arrays);
+    return result;
+}
+
+NDArray*
 NDArray_Flip(NDArray *a, NDArray *axis)
 {
 

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -233,7 +233,7 @@ NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices) {
         new_strides[new_dim_step] = NDArray_STRIDES(array)[orig_dim] * step;
         new_shape[new_dim_step] = n_steps;
 
-        if (NDArray_NUMELEMENTS(indexes[i]) != 0) {
+        if (NDArray_NUMELEMENTS(indexes[i]) == 1) {
             new_dim--;
             new_dim_step--;
         }

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -722,3 +722,9 @@ NDArray_Squeeze(NDArray *a, NDArray *axis)
     NDArray_RemoveAxesInPlace(ret, unit_dims);
     return ret;
 }
+
+NDArray*
+NDArray_Flip(NDArray *a, NDArray *axis)
+{
+
+}

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -773,6 +773,48 @@ NDArray_SwapAxes(NDArray *a, int axis1, int axis2)
 }
 
 NDArray*
+NDArray_Rollaxis(NDArray *a, int axis, int start)
+{
+    NDArray *result;
+    int n = NDArray_NDIM(a);
+
+    if (check_and_adjust_axis_msg(&axis, n) < 0) {
+        return NULL;
+    }
+
+    if (start < 0) start += n;
+
+    if (!(0 <= start < n + 1)) {
+        zend_throw_error(NULL, "'%s' arg requires %d <= %s < %d, but %d was passed in", "start", -n, "start", n+1, start);
+        return NULL;
+    }
+
+    if (axis < start) start -= 1;
+
+    if (axis == start) {
+        return NDArray_Copy(a, NDArray_DEVICE(a));
+    }
+
+    int *axes = emalloc(sizeof(int) * n);
+    for (int i = 0; i < n; i++) {
+        axes[i] = i;
+    }
+
+    for (int i = n; i > start; i--) {
+        axes[i] = axes[i - 1];
+    }
+    axes[start] = axis;
+
+    NDArray_Dims dims;
+    dims.len = n;
+    dims.ptr = axes;
+
+    result = NDArray_Transpose(a, &dims);
+    efree(axes);
+    return result;
+}
+
+NDArray*
 NDArray_Flip(NDArray *a, NDArray *axis)
 {
 

--- a/src/manipulation.c
+++ b/src/manipulation.c
@@ -198,7 +198,7 @@ NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices) {
 
     int new_strides[NDARRAY_MAX_DIMS];
     int new_shape[NDARRAY_MAX_DIMS];
-    int i, start = 0, stop = 0, step = 0, n_steps = 0, new_dim = 0, orig_dim = 0;
+    int i, start = 0, stop = 0, step = 0, n_steps = 0, new_dim = NDArray_NDIM(array), orig_dim = 0, new_dim_step = 0;
     char *data_ptr = NDArray_DATA(array);
 
     SliceObject sliceobj;
@@ -230,9 +230,14 @@ NDArray_Slice(NDArray* array, NDArray** indexes, int num_indices) {
             start = 0;
         }
         data_ptr += NDArray_STRIDES(array)[orig_dim] * start;
-        new_strides[new_dim] = NDArray_STRIDES(array)[orig_dim] * step;
-        new_shape[new_dim] = n_steps;
-        new_dim += 1;
+        new_strides[new_dim_step] = NDArray_STRIDES(array)[orig_dim] * step;
+        new_shape[new_dim_step] = n_steps;
+
+        if (NDArray_NUMELEMENTS(indexes[i]) != 0) {
+            new_dim--;
+            new_dim_step--;
+        }
+        new_dim_step += 1;
         orig_dim += 1;
         if (sliceobj.start != NULL) {
             efree(sliceobj.start);

--- a/src/manipulation.h
+++ b/src/manipulation.h
@@ -22,5 +22,6 @@ NDArray* NDArray_Flip(NDArray *a, NDArray *axis);
 NDArray* NDArray_Squeeze(NDArray *a, NDArray *axis);
 NDArray* NDArray_SwapAxes(NDArray *a, int axis1, int axis2);
 NDArray* NDArray_Rollaxis(NDArray *a, int axis, int start);
+NDArray* NDArray_Moveaxis(NDArray *a, int* src, int* dest, int n_source, int n_dest);
 int NDArray_ConvertMultiAxis(NDArray *axis_in, int ndim, bool *out_axis_flags);
 #endif //PHPSCI_NDARRAY_MANIPULATION_H

--- a/src/manipulation.h
+++ b/src/manipulation.h
@@ -21,5 +21,6 @@ NDArray* NDArray_ConcatenateFlat(NDArray **arrays, int num_arrays);
 NDArray* NDArray_Flip(NDArray *a, NDArray *axis);
 NDArray* NDArray_Squeeze(NDArray *a, NDArray *axis);
 NDArray* NDArray_SwapAxes(NDArray *a, int axis1, int axis2);
+NDArray* NDArray_Rollaxis(NDArray *a, int axis, int start);
 int NDArray_ConvertMultiAxis(NDArray *axis_in, int ndim, bool *out_axis_flags);
 #endif //PHPSCI_NDARRAY_MANIPULATION_H

--- a/src/manipulation.h
+++ b/src/manipulation.h
@@ -27,5 +27,6 @@ NDArray* NDArray_Concatenate(NDArray **arrays, int narrays, int axis);
 NDArray* NDArray_VSTACK(NDArray **arrays, int narrays);
 NDArray* NDArray_HSTACK(NDArray **arrays, int narrays);
 NDArray* NDArray_DSTACK(NDArray **arrays, int narrays);
+NDArray* NDArray_ColumnStack(NDArray **arrays, int narrays);
 int NDArray_ConvertMultiAxis(NDArray *axis_in, int ndim, bool *out_axis_flags);
 #endif //PHPSCI_NDARRAY_MANIPULATION_H

--- a/src/manipulation.h
+++ b/src/manipulation.h
@@ -4,7 +4,7 @@
 #include "ndarray.h"
 
 
-NDArray* NDArray_Transpose(NDArray *a);
+NDArray* NDArray_Transpose(NDArray *a, NDArray_Dims *permute);
 NDArray* NDArray_Reshape(NDArray *target, int *new_shape, int ndim);
 NDArray* NDArray_Flatten(NDArray *target);
 void reverse_copy(const int* src, int* dest, int size);
@@ -20,5 +20,6 @@ NDArray* NDArray_AtLeast3D(NDArray *a);
 NDArray* NDArray_ConcatenateFlat(NDArray **arrays, int num_arrays);
 NDArray* NDArray_Flip(NDArray *a, NDArray *axis);
 NDArray* NDArray_Squeeze(NDArray *a, NDArray *axis);
+NDArray* NDArray_SwapAxes(NDArray *a, int axis1, int axis2);
 int NDArray_ConvertMultiAxis(NDArray *axis_in, int ndim, bool *out_axis_flags);
 #endif //PHPSCI_NDARRAY_MANIPULATION_H

--- a/src/manipulation.h
+++ b/src/manipulation.h
@@ -23,5 +23,9 @@ NDArray* NDArray_Squeeze(NDArray *a, NDArray *axis);
 NDArray* NDArray_SwapAxes(NDArray *a, int axis1, int axis2);
 NDArray* NDArray_Rollaxis(NDArray *a, int axis, int start);
 NDArray* NDArray_Moveaxis(NDArray *a, int* src, int* dest, int n_source, int n_dest);
+NDArray* NDArray_Concatenate(NDArray **arrays, int narrays, int axis);
+NDArray* NDArray_VSTACK(NDArray **arrays, int narrays);
+NDArray* NDArray_HSTACK(NDArray **arrays, int narrays);
+NDArray* NDArray_DSTACK(NDArray **arrays, int narrays);
 int NDArray_ConvertMultiAxis(NDArray *axis_in, int ndim, bool *out_axis_flags);
 #endif //PHPSCI_NDARRAY_MANIPULATION_H

--- a/src/ndarray.h
+++ b/src/ndarray.h
@@ -96,6 +96,10 @@ NDArray_CLEARFLAGS(NDArray *arr, int flags) {
     (arr)->flags &= ~flags;
 }
 
+typedef struct {
+    int perm, stride;
+} ndarray_stride_sort_item;
+
 void NDArray_FREE(NDArray *array);
 char *NDArray_Print(NDArray *array, int do_return);
 NDArray *reduce(NDArray *array, int *axis, NDArray *(*operation)(NDArray *, NDArray *));
@@ -119,6 +123,11 @@ NDArray* NDArray_FromGD(zval *a, bool channel_last);
 void NDArray_ToGD(NDArray *a, NDArray *n_alpha, zval *output);
 void NDArray_Save(NDArray *a, char * filename, int length);
 NDArray* NDArray_Load(char * filename);
+NDArray* NDArray_AssignRawScalar(NDArray *dst, NDArray *src);
+int NDArray_AssignArray(NDArray *dst, NDArray *src);
+int NDArray_CompareLists(int const *l1, int const *l2, int n);
+void NDArray_CreateMultiSortedStridePerm(int narrays, NDArray **arrays, int ndim, int *out_strideperm);
+void NDArray_CreateSortedStridePerm(int ndim, int const *strides, ndarray_stride_sort_item *out_strideperm);
 
 #ifdef __cplusplus
 }

--- a/src/ndmath/calculation.c
+++ b/src/ndmath/calculation.c
@@ -119,10 +119,7 @@ NDArray_ArgMinMaxCommon(NDArray *op, int axis, int keepdims, bool is_argmax) {
             dims[j] = j + 1;
         }
         dims[NDArray_NDIM(ap) - 1] = axis;
-        //@todo Use transpose permutation
-        //op = NDArray_Transpose(ap, &newaxes);
-        op = NDArray_Transpose(ap);
-
+        op = NDArray_Transpose(ap, &newaxes);
         NDArray_FREE(ap);
         if (op == NULL) {
             return NULL;

--- a/src/ndmath/calculation.c
+++ b/src/ndmath/calculation.c
@@ -42,7 +42,6 @@ float_argmin(float *ip, int n, float *min_ind)
 {
     int i;
     float mp = *ip;
-
     *min_ind = 0;
 
 
@@ -53,16 +52,16 @@ float_argmin(float *ip, int n, float *min_ind)
 
     for (i = 1; i < n; i++) {
         ip++;
-        if (!(mp <= *ip)) {  /* negated, for correct nan handling */
+
+        if (!_LESS_THAN_OR_EQUAL(mp, *ip)) {
             mp = *ip;
-            *min_ind = (float)i;
+            *min_ind = i;
             if (isnanf(mp)) {
-                /* nan encountered, it's minimal */
                 break;
             }
         }
-
     }
+
     return 0;
 }
 

--- a/src/ndmath/calculation.h
+++ b/src/ndmath/calculation.h
@@ -5,6 +5,8 @@
 
 typedef int (NDArray_ArgFunc)(float*, int, float *);
 
+#define _LESS_THAN_OR_EQUAL(a,b) ((a) <= (b))
+
 NDArray * NDArray_ArgMinMaxCommon(NDArray *op, int axis, int keepdims, bool is_argmax);
 
 #endif //NUMPOWER_CALCULATION_H

--- a/src/ndmath/calculation.h
+++ b/src/ndmath/calculation.h
@@ -7,6 +7,6 @@ typedef int (NDArray_ArgFunc)(float*, int, float *);
 
 #define _LESS_THAN_OR_EQUAL(a,b) ((a) <= (b))
 
-NDArray * NDArray_ArgMinMaxCommon(NDArray *op, int axis, int keepdims, bool is_argmax);
+NDArray * NDArray_ArgMinMaxCommon(NDArray *op, int axis, bool keepdims, bool is_argmax);
 
 #endif //NUMPOWER_CALCULATION_H

--- a/src/ndmath/cuda/cuda_math.cu
+++ b/src/ndmath/cuda/cuda_math.cu
@@ -303,10 +303,20 @@ __global__
 void negateFloatKernel(float* d_array, int size) {
     int index = threadIdx.x + blockIdx.x * blockDim.x;
     if (index < size) {
-
         d_array[index] = -(d_array[index]);
     }
 }
+
+__global__
+void positiveFloatKernel(float* d_array, int size) {
+    int index = threadIdx.x + blockIdx.x * blockDim.x;
+    if (index < size) {
+        if (d_array[index] < 0) {
+            d_array[index] = -(d_array[index]);
+        }
+    }
+}
+
 
 __device__
 float sinc(float number) {
@@ -1360,6 +1370,14 @@ extern "C" {
         int blockSize = 256;  // Number of threads per block. This is a typical choice.
         int numBlocks = (nblocks + blockSize - 1) / blockSize;  // Number of blocks in the grid.
         negateFloatKernel<<<numBlocks, blockSize>>>(d_array, nblocks);
+        cudaDeviceSynchronize();
+    }
+
+    void
+    cuda_float_positive(int nblocks, float *d_array) {
+        int blockSize = 256;  // Number of threads per block. This is a typical choice.
+        int numBlocks = (nblocks + blockSize - 1) / blockSize;  // Number of blocks in the grid.
+        positiveFloatKernel<<<numBlocks, blockSize>>>(d_array, nblocks);
         cudaDeviceSynchronize();
     }
 

--- a/src/ndmath/cuda/cuda_math.cu
+++ b/src/ndmath/cuda/cuda_math.cu
@@ -317,6 +317,14 @@ void positiveFloatKernel(float* d_array, int size) {
     }
 }
 
+__global__
+void reciprocalFloatKernel(float* d_array, int size) {
+    int index = threadIdx.x + blockIdx.x * blockDim.x;
+    if (index < size) {
+        d_array[index] = 1.0f / (d_array[index]);
+    }
+}
+
 
 __device__
 float sinc(float number) {
@@ -1378,6 +1386,14 @@ extern "C" {
         int blockSize = 256;  // Number of threads per block. This is a typical choice.
         int numBlocks = (nblocks + blockSize - 1) / blockSize;  // Number of blocks in the grid.
         positiveFloatKernel<<<numBlocks, blockSize>>>(d_array, nblocks);
+        cudaDeviceSynchronize();
+    }
+
+    void
+    cuda_float_reciprocal(int nblocks, float *d_array) {
+        int blockSize = 256;  // Number of threads per block. This is a typical choice.
+        int numBlocks = (nblocks + blockSize - 1) / blockSize;  // Number of blocks in the grid.
+        reciprocalFloatKernel<<<numBlocks, blockSize>>>(d_array, nblocks);
         cudaDeviceSynchronize();
     }
 

--- a/src/ndmath/cuda/cuda_math.h
+++ b/src/ndmath/cuda/cuda_math.h
@@ -33,7 +33,6 @@ float cuda_min_float(float *a, int nelements);
 void cuda_pow_float(int nblocks, float *a, float *b, float *rtn, int nelements);
 int cuda_equal_float(int nblocks, float *a, float *b, int nelements);
 void cuda_sum_float(int nblocks, float *a, float *rtn, int nelements);
-void cuda_matmul_float(int nblocks, float *a, float *b, float *rtn, int widthA, int heightA, int widthB);
 void cuda_fill_float(float *a, float value, int n);
 int cuda_det_float(float *a, float *result, int n);
 void cuda_float_sin(int nblocks, float *d_array);
@@ -76,6 +75,7 @@ void cuda_lstsq_float(float* A, int m, int n, float* B, int k, float* X);
 NDArray* NDArrayMathGPU_ElementWise2F(NDArray* ndarray, ElementWiseFloatGPUOperation2F op, float val1, float val2);
 NDArray* NDArrayMathGPU_ElementWise1F(NDArray* ndarray, ElementWiseFloatGPUOperation1F op, float val1);
 void cuda_float_transpose(int tiledim, int blockrows, const float *d_in, float *d_out, int width, int height);
+void cuda_float_positive(int nblocks, float *d_array);
 
 #ifdef __cplusplus
 }

--- a/src/ndmath/cuda/cuda_math.h
+++ b/src/ndmath/cuda/cuda_math.h
@@ -76,6 +76,7 @@ NDArray* NDArrayMathGPU_ElementWise2F(NDArray* ndarray, ElementWiseFloatGPUOpera
 NDArray* NDArrayMathGPU_ElementWise1F(NDArray* ndarray, ElementWiseFloatGPUOperation1F op, float val1);
 void cuda_float_transpose(int tiledim, int blockrows, const float *d_in, float *d_out, int width, int height);
 void cuda_float_positive(int nblocks, float *d_array);
+void cuda_float_reciprocal(int nblocks, float *d_array);
 
 #ifdef __cplusplus
 }

--- a/src/ndmath/double_math.c
+++ b/src/ndmath/double_math.c
@@ -238,6 +238,11 @@ float float_negate(float val) {
     return -val;
 }
 
+float float_positive(float val) {
+    if (val < 0) return -val;
+    return val;
+}
+
 float float_sign(float val) {
     return (float)((val > 0.0f) - (val < 0.0f));
 }

--- a/src/ndmath/double_math.c
+++ b/src/ndmath/double_math.c
@@ -256,7 +256,10 @@ float float_round(float number, float decimals) {
     return roundf(number * factor) / factor;
 }
 
-float float_arctan2(float x, float y)
-{
+float float_arctan2(float x, float y) {
     return atan2f(x, y);
+}
+
+float float_reciprocal(float val) {
+    return 1 / val;
 }

--- a/src/ndmath/double_math.h
+++ b/src/ndmath/double_math.h
@@ -40,4 +40,5 @@ float float_clip(float val, float min, float max);
 float float_round(float number, float decimals);
 float float_rsqrt(float val);
 float float_arctan2(float x, float y);
+float float_positive(float val);
 #endif //PHPSCI_NDARRAY_DOUBLE_MATH_H

--- a/src/ndmath/double_math.h
+++ b/src/ndmath/double_math.h
@@ -41,4 +41,5 @@ float float_round(float number, float decimals);
 float float_rsqrt(float val);
 float float_arctan2(float x, float y);
 float float_positive(float val);
+float float_reciprocal(float val);
 #endif //PHPSCI_NDARRAY_DOUBLE_MATH_H

--- a/src/ndmath/linalg.c
+++ b/src/ndmath/linalg.c
@@ -137,7 +137,7 @@ NDArray_SVD(NDArray *target) {
     }
     if(NDArray_DEVICE(target_ptr) == NDARRAY_DEVICE_GPU) {
 #ifdef HAVE_CUBLAS
-        target_ptr = NDArray_Transpose(target);
+        target_ptr = NDArray_Transpose(target, NULL);
         vmalloc((void**)&Sf, sizeof(float) * smallest_dim);
         vmalloc((void**)&Uf, sizeof(float) * NDArray_SHAPE(target)[0] * NDArray_SHAPE(target)[0]);
         vmalloc((void**)&Vf, sizeof(float) * NDArray_SHAPE(target)[1] * NDArray_SHAPE(target)[1]);
@@ -425,7 +425,7 @@ NDArray_L1Norm(NDArray* target) {
     NDArray *rtn = NULL;
     float max_value = FLT_MIN;
     float *results = emalloc(sizeof(float) * NDArray_SHAPE(target)[NDArray_NDIM(target) - 2]);
-    NDArray *transposed = NDArray_Transpose(target);
+    NDArray *transposed = NDArray_Transpose(target, NULL);
     NDArray *ab = NDArray_Abs(transposed);
     NDArray_FREE(transposed);
     NDArray *slice;

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -96,6 +96,14 @@ final class NDArray {
     public static function positive(NDArray|array|float|int $a): NDArray|float|int {}
 
     /**
+     * `1 / x`, element-wise.
+     *
+     * @param NDArray|array|float|int $a Input array
+     * @return NDArray|float|int
+     */
+    public static function reciprocal(NDArray|array|float|int $a): NDArray|float|int {}
+
+    /**
      * Raises each element of an array $a to a specified power $b and returns a new array containing the result.
      *
      * Same as $a ** $b;

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -858,7 +858,7 @@ final class NDArray {
      *
      * - **1** - L1-Norm
      * - **2** - L2-Norm
- *
+     *
      * @param NDArray|array $a
      * @param int $order (1) L1-Norm, (2) L2-Norm
      * @return float
@@ -985,5 +985,23 @@ final class NDArray {
      */
     public static function arange(float|int $stop, float|int $start = 0, float|int $step = 1): NDArray {}
 
+    /**
+     * Remove axes of length one from $a.
+     *
+     * @param NDArray|array $a Input array
+     * @param int|int[] $axis Selects a subset of the entries of length one in the shape.
+     * If an axis is selected with shape entry greater than one, an error is raised.
+     * @return NDArray|float The input array, but with all or a subset of the dimensions of length 1 removed.
+     * This is always $a itself or $a view into $a. Note that if all axes are squeezed,
+     * the result is a 0d array and not a scalar.
+     */
+    public static function squeeze(NDArray|array $a, int|array $axis): NDArray|float {}
 
+    /**
+     * Extract a diagonal or construct a diagonal array.
+     *
+     * @param NDArray|array $a
+     * @return NDArray
+     */
+    public static function diag(NDArray|array $a): NDArray {}
 }

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -1004,4 +1004,13 @@ final class NDArray {
      * @return NDArray
      */
     public static function diag(NDArray|array $a): NDArray {}
+
+    /**
+     * Return a new array of given shape and type, filled with $fill_value.
+     *
+     * @param int[] $shape
+     * @param float|int $fill_value
+     * @return NDArray
+     */
+    public static function full(array $shape, float|int $fill_value): NDArray {}
 }

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -1008,9 +1008,17 @@ final class NDArray {
     /**
      * Return a new array of given shape and type, filled with $fill_value.
      *
-     * @param int[] $shape
-     * @param float|int $fill_value
+     * @param int[] $shape Shape of the new array
+     * @param float|int $fill_value Fill value
      * @return NDArray
      */
     public static function full(array $shape, float|int $fill_value): NDArray {}
+
+    /**
+     * Fill the array with a scalar value.
+     *
+     * @param float|int $fill_value Fill value
+     * @return NDArray
+     */
+    public static function fill(float|int $fill_value): NDArray {}
 }

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -745,6 +745,15 @@ final class NDArray {
     public static function dstack(array $arrays): NDArray {}
 
     /**
+     * Join a sequence of arrays along an existing axis.
+     *
+     * @param NDArray[] $arrays
+     * @param int|null $axis
+     * @return NDArray
+     */
+    public static function concatenate(array $arrays, ?int $axis = 0): NDArray {}
+
+    /**
      * Stack 1-D arrays as columns into a 2-D array.
      *
      * @param NDArray[] $arrays

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -685,10 +685,21 @@ final class NDArray {
      * Return the transpose of matrix `$a`
      *
      * @param NDArray|array|float|int $a Target array
+     * @param array|null $axes For an n-D array, if $axes are given, their order indicates how the axes are permuted
      * @return NDArray $a transposed
      */
-    public static function transpose(NDArray|array|float|int $a): NDArray {}
+    public static function transpose(NDArray|array|float|int $a, ?array $axes): NDArray {}
 
+
+    /**
+     * Interchange two axes of an array.
+     *
+     * @param NDArray|array|float|int $a Target array
+     * @param int $axis1 First axis
+     * @param int $axis2 Second axis
+     * @return NDArray $a transposed
+     */
+    public static function swapaxes(NDArray|array|float|int $a, int $axis1, int $axis2): NDArray {}
 
     /**
      * Creates a new NDArray from a PHP array.

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -77,7 +77,6 @@ final class NDArray {
      */
     public static function multiply(NDArray|array|float|int $a, NDArray|array|float|int $b): NDArray|float|int {}
 
-
     /**
      * Computes the element-wise negation (unary minus) of an array, returning a new array with the negation of each element.
      *
@@ -87,6 +86,14 @@ final class NDArray {
      * @return NDArray|float|int The multiplication of $a * -1
      */
     public static function negative(NDArray|array|float|int $a): NDArray|float|int {}
+
+    /**
+     * Numerical positive, element-wise.
+     *
+     * @param NDArray|array|float|int $a Input array
+     * @return NDArray|float|int
+     */
+    public static function positive(NDArray|array|float|int $a): NDArray|float|int {}
 
     /**
      * Raises each element of an array $a to a specified power $b and returns a new array containing the result.
@@ -1029,7 +1036,7 @@ final class NDArray {
      * @param int|null $axis If NULL, the index is into the flattened array, otherwise along the specified axis.
      * @return NDArray Array of indices into the array. It has the same shape as $a with the dimension along $axis removed.
      */
-    public function argmin(NDArray|array $a, ?int $axis): NDArray {}
+    public static function argmin(NDArray|array $a, ?int $axis): NDArray {}
 
     /**
      * Returns the indices of the maximum values along an axis.
@@ -1038,5 +1045,5 @@ final class NDArray {
      * @param int|null $axis If NULL, the index is into the flattened array, otherwise along the specified axis.
      * @return NDArray Array of indices into the array. It has the same shape as $a with the dimension along axis removed.
      */
-    public function argmax(NDArray|array $a, ?int $axis): NDArray {}
+    public static function argmax(NDArray|array $a, ?int $axis): NDArray {}
 }

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -1088,4 +1088,28 @@ final class NDArray {
      * @return NDArray Array of indices into the array. It has the same shape as $a with the dimension along axis removed.
      */
     public static function argmax(NDArray|array $a, ?int $axis, bool $keepdims = false): NDArray {}
+
+    /**
+     * Array slicing, each argument represents a slice of a dimension.
+     *
+     * Empty arrays represent all values of a dimension, arrays with values are treated in
+     * the format [start, stop, step], when only one value exists, it is automatically
+     * assigned to stop, the default value of start is 0 and step is 1.
+     *
+     * When instead of an array, a number is passed, it is also assigned to the
+     * stop of that dimension.
+     *
+     * Ex: Get the first row of a matrix:
+     * $array->slice(0)
+     *
+     * Ex: Get the last column of a matrix:
+     * $array->slice([], -1);
+     *
+     * Ex: Get the first two columns of the first row:
+     * $array->slice(0, [0,2]);
+     *
+     * @param array ...$indices
+     * @return NDArray|float
+     */
+    public function slice(...$indices): NDArray|float {};
 }

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -711,6 +711,16 @@ final class NDArray {
     public static function rollaxis(NDArray|array|float|int $a, int $axis, int $start = 0): NDArray {}
 
     /**
+     * Move axes of an array to new positions.
+     *
+     * @param NDArray|array|float|int $a Target array
+     * @param int|array $source
+     * @param int|array $destination
+     * @return NDArray $a
+     */
+    public static function moveaxis(NDArray|array|float|int $a, int|array $source, int|array $destination): NDArray {}
+
+    /**
      * Creates a new NDArray from a PHP array.
      *
      * It is the equivalent of `new NDArray($array);`

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -96,7 +96,9 @@ final class NDArray {
     public static function positive(NDArray|array|float|int $a): NDArray|float|int {}
 
     /**
-     * `1 / x`, element-wise.
+     * Return the reciprocal of the argument, element-wise.
+     *
+     * Calculates `1 / $a`
      *
      * @param NDArray|array|float|int $a Input array
      * @return NDArray|float|int

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -754,6 +754,16 @@ final class NDArray {
     public static function concatenate(array $arrays, ?int $axis = 0): NDArray {}
 
     /**
+     * Append values to the end of an array.
+     *
+     * @param NDArray|array $array
+     * @param NDArray|array $values
+     * @param int|null $axis
+     * @return NDArray
+     */
+    public static function append(NDArray|array $array, NDArray|array $values, ?int $axis): NDArray {}
+
+    /**
      * Stack 1-D arrays as columns into a 2-D array.
      *
      * @param NDArray[] $arrays

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -690,16 +690,25 @@ final class NDArray {
      */
     public static function transpose(NDArray|array|float|int $a, ?array $axes): NDArray {}
 
-
     /**
      * Interchange two axes of an array.
      *
      * @param NDArray|array|float|int $a Target array
      * @param int $axis1 First axis
      * @param int $axis2 Second axis
-     * @return NDArray $a transposed
+     * @return NDArray $a
      */
     public static function swapaxes(NDArray|array|float|int $a, int $axis1, int $axis2): NDArray {}
+
+    /**
+     * Roll the specified axis backwards, until it lies in a given position.
+     *
+     * @param NDArray|array|float|int $a Target array
+     * @param int $axis
+     * @param int $start
+     * @return NDArray $a
+     */
+    public static function rollaxis(NDArray|array|float|int $a, int $axis, int $start = 0): NDArray {}
 
     /**
      * Creates a new NDArray from a PHP array.
@@ -1055,16 +1064,18 @@ final class NDArray {
      *
      * @param NDArray|array $a Target array
      * @param int|null $axis If NULL, the index is into the flattened array, otherwise along the specified axis.
+     * @param bool $keepdims
      * @return NDArray Array of indices into the array. It has the same shape as $a with the dimension along $axis removed.
      */
-    public static function argmin(NDArray|array $a, ?int $axis): NDArray {}
+    public static function argmin(NDArray|array $a, ?int $axis, bool $keepdims = false): NDArray {}
 
     /**
      * Returns the indices of the maximum values along an axis.
      *
      * @param NDArray|array $a Target array
      * @param int|null $axis If NULL, the index is into the flattened array, otherwise along the specified axis.
+     * @param bool $keepdims
      * @return NDArray Array of indices into the array. It has the same shape as $a with the dimension along axis removed.
      */
-    public static function argmax(NDArray|array $a, ?int $axis): NDArray {}
+    public static function argmax(NDArray|array $a, ?int $axis, bool $keepdims = false): NDArray {}
 }

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -745,6 +745,14 @@ final class NDArray {
     public static function dstack(array $arrays): NDArray {}
 
     /**
+     * Stack 1-D arrays as columns into a 2-D array.
+     *
+     * @param NDArray[] $arrays
+     * @return NDArray
+     */
+    public static function column_stack(array $arrays): NDArray {}
+
+    /**
      * Creates a new NDArray from a PHP array.
      *
      * It is the equivalent of `new NDArray($array);`

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -696,7 +696,7 @@ final class NDArray {
      * @param NDArray|array|float|int $a Target array
      * @param int $axis1 First axis
      * @param int $axis2 Second axis
-     * @return NDArray $a
+     * @return NDArray
      */
     public static function swapaxes(NDArray|array|float|int $a, int $axis1, int $axis2): NDArray {}
 
@@ -706,7 +706,7 @@ final class NDArray {
      * @param NDArray|array|float|int $a Target array
      * @param int $axis
      * @param int $start
-     * @return NDArray $a
+     * @return NDArray
      */
     public static function rollaxis(NDArray|array|float|int $a, int $axis, int $start = 0): NDArray {}
 
@@ -716,9 +716,33 @@ final class NDArray {
      * @param NDArray|array|float|int $a Target array
      * @param int|array $source
      * @param int|array $destination
-     * @return NDArray $a
+     * @return NDArray
      */
     public static function moveaxis(NDArray|array|float|int $a, int|array $source, int|array $destination): NDArray {}
+
+    /**
+     * Stack arrays in sequence vertically (row wise).
+     *
+     * @param NDArray[] $arrays
+     * @return NDArray
+     */
+    public static function vstack(array $arrays): NDArray {}
+
+    /**
+     * Stack arrays in sequence horizontally (column wise).
+     *
+     * @param NDArray[] $arrays
+     * @return NDArray
+     */
+    public static function hstack(array $arrays): NDArray {}
+
+    /**
+     * Stack arrays in sequence depth wise (along third axis).
+     *
+     * @param NDArray[] $arrays
+     * @return NDArray
+     */
+    public static function dstack(array $arrays): NDArray {}
 
     /**
      * Creates a new NDArray from a PHP array.

--- a/stubs/numpower.stubs.php
+++ b/stubs/numpower.stubs.php
@@ -1020,5 +1020,23 @@ final class NDArray {
      * @param float|int $fill_value Fill value
      * @return NDArray
      */
-    public static function fill(float|int $fill_value): NDArray {}
+    public function fill(float|int $fill_value): NDArray {}
+
+    /**
+     * Returns the indices of the minimum values along an axis.
+     *
+     * @param NDArray|array $a Target array
+     * @param int|null $axis If NULL, the index is into the flattened array, otherwise along the specified axis.
+     * @return NDArray Array of indices into the array. It has the same shape as $a with the dimension along $axis removed.
+     */
+    public function argmin(NDArray|array $a, ?int $axis): NDArray {}
+
+    /**
+     * Returns the indices of the maximum values along an axis.
+     *
+     * @param NDArray|array $a Target array
+     * @param int|null $axis If NULL, the index is into the flattened array, otherwise along the specified axis.
+     * @return NDArray Array of indices into the array. It has the same shape as $a with the dimension along axis removed.
+     */
+    public function argmax(NDArray|array $a, ?int $axis): NDArray {}
 }

--- a/tests/manipulation/003-ndarray-append.phpt
+++ b/tests/manipulation/003-ndarray-append.phpt
@@ -7,9 +7,9 @@ use \NDArray as nd;
 $a = nd::array([1, 2, 3, 4]);
 $b = nd::array([5, 6, 7, 8]);
 
-print_r(nd::append([$a, $b])->toArray());
-print_r(nd::append([$a, $a])->toArray());
-print_r(nd::append([[1, 2, 3, 4], [1, 2, 3, 4]])->toArray());
+print_r(nd::append($a, $b)->toArray());
+print_r(nd::append($a, $a)->toArray());
+print_r(nd::append([1, 2, 3, 4], [1, 2, 3, 4])->toArray());
 ?>
 --EXPECT--
 Array


### PR DESCRIPTION
This is an update package that implements new methods and new features to existing methods for the 0.6.0 update.

## Updated: NDArray::transpose
Transpose now allows the user to specify permutation axes.

## Updated: NDArray::squeeze
Now support axis parameter

## New: NDArray::full
Creates a new array initialized with a user-specified value.

## New: NDArray->fill
Fills an existing array with the user-specified value.

## New: NDArray::positive
Returns a copy of the NDArray with all positive values.

## New: NDArray::reciprocal
Returns the reciprocal of the matrix, element-wise.

## New: NDArray::swapaxes
Interchange array axes.

## New: NDArray::argmin
Return the indices of the minimum values over a specified axis.

## New:: NDArray::argmax
Return the indices of the maximimum values over a specified axis.

## New:: NDArray::rollaxis
Roll the specified axis backwards, until it lies in a given position.

## New:: NDArray::moveaxis
Move axes of an array to new positions.

## New:: NDArray::hstack
Stack arrays in sequence horizontally (column wise).

## New:: NDArray::vstack
Stack arrays in sequence vertically (row wise).

## New:: NDArray::dstack
Stack arrays in sequence depth wise (along third axis).

## New:: NDArray::column_stack
Stack 1-D arrays as columns into a 2-D array.

## New:: NDArray::concatenate
Join a sequence of arrays along an existing axis.

## New:: NDArray::append
Append values to the end of an array.